### PR TITLE
Apply default network bandwidth to tasks if not provided.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -378,6 +378,7 @@ set(MASTER_SRC
   master/detector/detector.cpp
   master/detector/standalone.cpp
   master/detector/zookeeper.cpp
+  master/resources/network_bandwidth.cpp
   )
 
 set(MESSAGES_SRC

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -962,6 +962,7 @@ libmesos_no_3rdparty_la_SOURCES +=					\
   master/detector/detector.cpp						\
   master/detector/standalone.cpp					\
   master/detector/zookeeper.cpp						\
+  master/resources/network_bandwidth.cpp							\
   messages/messages.cpp							\
   module/manager.cpp							\
   oci/spec.cpp								\
@@ -2349,6 +2350,7 @@ mesos_tests_SOURCES =						\
   tests/master_contender_detector_tests.cpp			\
   tests/master_maintenance_tests.cpp				\
   tests/master_quota_tests.cpp					\
+  tests/master_resources_network_bandwidth_tests.cpp				\
   tests/master_slave_reconciliation_tests.cpp			\
   tests/master_tests.cpp					\
   tests/master_validation_tests.cpp				\

--- a/src/master/master.cpp
+++ b/src/master/master.cpp
@@ -86,6 +86,7 @@
 
 #include "master/flags.hpp"
 #include "master/master.hpp"
+#include "master/resources/network_bandwidth.hpp"
 #include "master/weights.hpp"
 
 #include "module/manager.hpp"
@@ -4065,6 +4066,10 @@ void Master::accept(
     }
   }
 
+  CHECK_SOME(slaveId);
+  Slave* slave = slaves.registered.get(slaveId.get());
+  CHECK_NOTNULL(slave);
+
   // We make various adjustments to the `Offer::Operation`s,
   // typically for backward/forward compatibility.
   // TODO(mpark): Pull this out to a master normalization utility.
@@ -4118,6 +4123,11 @@ void Master::accept(
               task.mutable_health_check()->set_type(HealthCheck::HTTP);
             }
           }
+          Try<Nothing> result = resources::enforceNetworkBandwidthAllocation(
+            slave->totalResources, task);
+          if(result.isError()) {
+            LOG(WARNING) << result.error();
+          }
         }
 
         break;
@@ -4135,6 +4145,11 @@ void Master::accept(
           if (!task.has_executor()) {
             task.mutable_executor()->CopyFrom(executor);
           }
+          Try<Nothing> result = resources::enforceNetworkBandwidthAllocation(
+            slave->totalResources, task);
+          if(result.isError()) {
+            LOG(WARNING) << result.error();
+          }
         }
 
         break;
@@ -4145,10 +4160,6 @@ void Master::accept(
       }
     }
   }
-
-  CHECK_SOME(slaveId);
-  Slave* slave = slaves.registered.get(slaveId.get());
-  CHECK_NOTNULL(slave);
 
   LOG(INFO) << "Processing ACCEPT call for offers: " << accept.offer_ids()
             << " on agent " << *slave << " for framework " << *framework;

--- a/src/master/resources/network_bandwidth.cpp
+++ b/src/master/resources/network_bandwidth.cpp
@@ -1,0 +1,221 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+
+#include "master/resources/network_bandwidth.hpp"
+
+#include <mesos/resources.hpp>
+
+#include "slave/slave.hpp"
+
+namespace mesos {
+namespace resources {
+
+using namespace std;
+
+using mesos::internal::slave::Slave;
+
+const double EPSYLON = 0.001;
+
+const string NETWORK_BANDWIDTH_LABEL_NAME = "NETWORK_BANDWIDTH_RESOURCE";
+
+const string NETWORK_BANDWIDTH_RESOURCE_NAME = "network_bandwidth";
+const string CPUS_RESOURCE_NAME = "cpus";
+
+
+/**
+ * @brief Return the first label matching a given key.
+ *
+ * @param labels The set of labels to look into.
+ * @param labelKey The key of the label to find.
+ * @return Return the label if it finds it otherwise None.
+ */
+Option<Label> getLabel(
+  const Labels& labels,
+  const string& labelKey) {
+  foreach(const Label& label, labels.labels()) {
+    if(label.key() == labelKey) {
+      return label;
+    }
+  }
+  return None();
+}
+
+
+/**
+ * @brief Add network bandwidth to a task.
+ *
+ * @param task The task to add network bandwidth to.
+ * @param amount The amount of network bandwidth in Mbps.
+ */
+void addNetworkBandwidth(TaskInfo& task, double amount) {
+  // At this point, we declare the amount of network bandwidth relative to the
+  // number of CPU shares.
+  Resource* networkBandwidth = task.add_resources();
+  networkBandwidth->set_name(NETWORK_BANDWIDTH_RESOURCE_NAME);
+  networkBandwidth->set_type(mesos::Value::SCALAR);
+
+  networkBandwidth->mutable_scalar()->set_value(amount);
+  networkBandwidth->set_allocated_allocation_info(
+        mesos::Resource_AllocationInfo().New());
+  networkBandwidth->mutable_allocation_info()->set_role("*");
+}
+
+
+/**
+ * @brief Compute the amount of network bandwidth relative to
+ *   the share of reserved CPU and the network bandwidth declared on the
+ *   slave.
+ *
+ * @param slaveTotalResources The global resources advertised by the slave.
+ * @return The amount of network bandwidth relative to the share of reserved
+ *   CPU.
+ */
+Try<Option<double>> computeNetworkBandwidthBasedOnShareOfCpu(
+  const Resources& taskResources,
+  const Resources& slaveTotalResources) {
+  // The following constant is defining the total amount of network bandwidth
+  // pool to allocate from when a task does not define network bandwidth
+  // reservation.
+  // This constant is in Mbps and is completely specific to Criteo.
+  //
+  // Note: We need to make sure network bandwidth advertised by the slaves has
+  // the same unit.
+  //
+  // TODO(clems4ever): make this parameterizable with a flag.
+  double DEFAULT_ALLOCATABLE_NETWORK_BANDWIDTH_IN_MBPS = 2000;
+
+  Option<double> totalCpus = slaveTotalResources.cpus();
+  Option<double> reservedCpus = taskResources.cpus();
+
+  if(totalCpus.isNone()) {
+    return Error("No CPU advertised by the slave. " \
+                 "Cannot deduce network bandwidth.");
+  }
+
+  if(reservedCpus.isNone()) {
+    return Error("No CPU declared in the task. " \
+                 "Cannot deduce network bandwidth.");
+  }
+
+  // We protect ourselves from a division by 0 even though it should not
+  // happen since a resource cannot be equal to 0. It would be filtered out
+  // when injected in Resources. Plus, it is unlikely that a slave declares 0
+  // or close to 0 cpus.
+  if(std::abs(totalCpus.get()) < EPSYLON) {
+    return 0.0;
+  }
+
+  return reservedCpus.get() /
+    totalCpus.get() *
+    DEFAULT_ALLOCATABLE_NETWORK_BANDWIDTH_IN_MBPS;
+}
+
+
+/**
+ * @brief Get an amount of network bandwidth, if any, from a set of labels.
+ *
+ * @param labels The set of labels to find network bandwidth amount in.
+ * @return The amount of network bandwidth declared in the label if it is
+ *   provided, None if the label is not provided and Error if there was
+ *   an error while extracting the network bandwidth amount.
+ */
+Try<Option<double>> getNetworkBandwidthFromLabel(
+  const Labels& labels) {
+  Option<Label> networkBandwidthLabel =
+    getLabel(labels, NETWORK_BANDWIDTH_LABEL_NAME);
+
+  if(networkBandwidthLabel.isSome()) {
+    LOG(INFO) << "Network bandwidth is specified in a label. " \
+                 "Taking the value.";
+
+    try {
+      // Parse the amount of network bandwidth.
+      return std::stof(
+        networkBandwidthLabel.get().value());
+    }
+    catch(const std::invalid_argument&) {
+      return Error("Invalid network bandwidth resource format. "\
+                   "Should be an integer.");
+    }
+    catch(const std::out_of_range&) {
+      return Error("Network bandwidth amount is out of range.");
+    }
+  }
+  return None();
+}
+
+
+/**
+ * @brief Enforce network bandwidth allocation (see header for more details).
+ *
+ * @param slaveTotalResources The resources declared on the slave.
+ * @param task The task to enforce network bandwidth for.
+ * @return Nothing if no enforcement is done or if it is successful, otherwise
+ *  an Error.
+ *
+ * TODO(clems4ever): Be able to consume role resources as well as unreserved.
+ */
+Try<Nothing> enforceNetworkBandwidthAllocation(
+  const Resources& slaveTotalResources,
+  TaskInfo& task)
+{
+  // We first check if network bandwidth is already declared. In that case
+  // we do not enforce allocation.
+  Option<Value::Scalar> networkBandwidthResource =
+    Resources(task.resources())
+      .get<Value::Scalar>(NETWORK_BANDWIDTH_RESOURCE_NAME);
+
+  if(networkBandwidthResource.isSome()) {
+    LOG(INFO) << "Network bandwidth is specified in resources. " \
+                 "No enforcement done.";
+    return Nothing(); // Nothing to enforce if network bandwidth is declared.
+  }
+
+  // We then check if network bandwidth is provided by label in case of
+  // schedulers not supporting network bandwidth offer matching.
+  Try<Option<double>> networkBandwidthFromLabel =
+      getNetworkBandwidthFromLabel(task.labels());
+
+  if(networkBandwidthFromLabel.isError()) {
+    return Error(networkBandwidthFromLabel.error());
+  }
+
+  if(networkBandwidthFromLabel.get().isSome()) {
+    addNetworkBandwidth(task, networkBandwidthFromLabel.get().get());
+    return Nothing();
+  }
+
+  // At this point, we enforce the network bandwidth allocation by reserving
+  // network bandwidth relative to the share of CPU reserved on the slave.
+  Try<Option<double>> defaultNetworkBandwidth =
+      computeNetworkBandwidthBasedOnShareOfCpu(
+        task.resources(),
+        slaveTotalResources);
+
+  if(defaultNetworkBandwidth.isError()) {
+    return Error(defaultNetworkBandwidth.error());
+  }
+
+  if(defaultNetworkBandwidth.get().isSome()) {
+    addNetworkBandwidth(task, defaultNetworkBandwidth.get().get());
+  }
+  return Nothing();
+}
+
+} // namespace resources {
+} // namespace mesos {

--- a/src/master/resources/network_bandwidth.hpp
+++ b/src/master/resources/network_bandwidth.hpp
@@ -1,0 +1,57 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef __MASTER_RESOURCES_NETWORK_BANDWIDTH_HPP__
+#define __MASTER_RESOURCES_NETWORK_BANDWIDTH_HPP__
+
+#include <mesos/mesos.hpp>
+#include <mesos/resources.hpp>
+
+#include <stout/nothing.hpp>
+#include <stout/try.hpp>
+
+namespace mesos {
+namespace resources {
+
+/**
+ * @brief Enforce network bandwidth reservation for a given task.
+ *
+ * We ensure every task has a default allocated network bandwidth on slaves
+ * declaring network bandwidth.
+ * The amount of allocated network bandwidth is either provided by the
+ * scheduler via resources or labels. Otherwise it is computed and added to the
+ * task. The computation is the following:
+ *
+ * TaskNetworkBandwidth = TaskCpus / SlaveCpus * SlaveNetworkBandwidth.
+ *
+ * This computation is definitely Criteo specific and could be anything else.
+ *
+ * Note: this amount of network bandwidth is taken out from unreserved
+ *       resources since we don't take roles into account yet.
+ *
+ * @param slaveTotalResources The resources declared on the slave.
+ * @param task The task to enforce network bandwidth declaration for.
+ * @return Nothing if enforcement is not applied or successful otherwise an
+ *         Error.
+ */
+Try<Nothing> enforceNetworkBandwidthAllocation(
+  const Resources& slaveTotalResources,
+  TaskInfo& task);
+
+} // namespace resources {
+} // namespace mesos {
+
+#endif // __MASTER_METRICS_HPP__

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -109,6 +109,7 @@ set(MESOS_TESTS_SRC
   http_authentication_tests.cpp
   http_fault_tolerance_tests.cpp
   master_maintenance_tests.cpp
+  master_resources_network_bandwidth_tests.cpp
   master_slave_reconciliation_tests.cpp
   partition_tests.cpp
   paths_tests.cpp

--- a/src/tests/master_resources_network_bandwidth_tests.cpp
+++ b/src/tests/master_resources_network_bandwidth_tests.cpp
@@ -1,0 +1,291 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+
+#include <gmock/gmock.h>
+
+#include "master/resources/network_bandwidth.hpp"
+
+#include <stout/gtest.hpp>
+
+namespace mesos {
+bool operator==(const Resource& left, const Resource& right)
+{
+  return left.name() == right.name()
+    && left.type() == right.type()
+    && left.scalar() == right.scalar()
+    && left.allocation_info().role() == right.allocation_info().role();
+}
+} // namespace mesos {
+
+namespace mesos {
+namespace internal {
+namespace tests {
+
+using std::string;
+
+const string NETWORK_BANDWIDTH_RESOURCE_LABEL = "NETWORK_BANDWIDTH_RESOURCE";
+const string NETWORK_BANDWIDTH_RESOURCE_NAME = "network_bandwidth";
+const string CPUS_RESOURCE_NAME = "cpus";
+
+Option<Resource> getUnreservedResource(
+    const Resources& resources,
+    const string& resourceName) {
+  foreach(const Resource& resource, resources) {
+    if(resource.name() == resourceName &&
+       resource.allocation_info().role() == "*") {
+      return resource;
+    }
+  }
+  return None();
+}
+
+void ASSERT_HAS_NETWORK_BANDWIDTH(
+  const Resources& resources,
+  const Resource& expectedNetworkBandwidth) {
+  Option<Resource> networkBandwidth = getUnreservedResource(
+    resources, NETWORK_BANDWIDTH_RESOURCE_NAME);
+
+  if(networkBandwidth.isNone()) {
+    ASSERT_TRUE(false) << "Network bandwidth should be present.";
+  }
+  else {
+    ASSERT_EQ(networkBandwidth.get(), expectedNetworkBandwidth);
+  }
+}
+
+void ASSERT_HAS_NO_NETWORK_BANDWIDTH(
+  const Resources& resources) {
+  Option<Resource> networkBandwidth = getUnreservedResource(
+    resources, NETWORK_BANDWIDTH_RESOURCE_NAME);
+
+  if(networkBandwidth.isSome()) {
+    ASSERT_TRUE(false) << "There should not be any declared network bandwidth.";
+  }
+}
+
+// Helper function create any kind of unreserved resource.
+Resource createResource(const string& resourceName, double amount) {
+  Resource resource;
+  resource.set_name(resourceName);
+  resource.set_type(mesos::Value::SCALAR);
+  resource.mutable_scalar()->set_value(amount);
+  resource.mutable_allocation_info()->set_role("*");
+  return resource;
+}
+
+Resource CPU(double amount) {
+  return createResource(CPUS_RESOURCE_NAME, amount);
+}
+
+Resource NetworkBandwidth(double amount) {
+  return createResource(NETWORK_BANDWIDTH_RESOURCE_NAME, amount);
+}
+
+// Given a task has declared network bandwidth
+// Then enforcement should let the task goes through without update.
+TEST(MasterResourcesNetworkBandwidthTest, ConsumeDeclaredNetworkBandwidth) {
+  TaskInfo task;
+  Resources totalSlaveResources;
+
+  // Add 30Mbps of network bandwidth to the task.
+  task.mutable_resources()->Add()->CopyFrom(NetworkBandwidth(30));
+
+  Try<Nothing> result = resources::enforceNetworkBandwidthAllocation(
+    totalSlaveResources, task);
+
+  ASSERT_SOME(result);
+  ASSERT_HAS_NETWORK_BANDWIDTH(task.resources(), NetworkBandwidth(30));
+}
+
+
+// Given a task is declaring network bandwidth in a label
+// Then the enforcement adds it to the task.
+TEST(MasterResourcesNetworkBandwidthTest, ConsumeNetworkBandwidthInLabel) {
+  TaskInfo task;
+  Resources totalSlaveResources;
+
+  // Add 50Mbps of network bandwidth by label.
+  Label* label = task.mutable_labels()->add_labels();
+  label->set_key(NETWORK_BANDWIDTH_RESOURCE_LABEL);
+  label->set_value("50");
+
+  Try<Nothing> result = resources::enforceNetworkBandwidthAllocation(
+    totalSlaveResources, task);
+
+  ASSERT_SOME(result);
+  ASSERT_HAS_NETWORK_BANDWIDTH(task.resources(), NetworkBandwidth(50));
+}
+
+
+// Given a task is declaring network bandwidth in a label with wrong format
+// Then the enforcement should fail with an error
+TEST(MasterResourcesNetworkBandwidthTest, WrongFormatLabel) {
+  TaskInfo task;
+  Resources totalSlaveResources;
+
+  // Add 50Mbps of network bandwidth by label.
+  Label* label = task.mutable_labels()->add_labels();
+  label->set_key(NETWORK_BANDWIDTH_RESOURCE_LABEL);
+  label->set_value("a50");
+
+  Try<Nothing> result = resources::enforceNetworkBandwidthAllocation(
+    totalSlaveResources, task);
+
+  ASSERT_ERROR(result);
+  ASSERT_EQ("Invalid network bandwidth resource format. "\
+            "Should be an integer.", result.error());
+}
+
+
+// Given a task is declaring an out of range amount of network bandwidth in a
+//       label
+// Then the enforcement should fail with an error
+TEST(MasterResourcesNetworkBandwidthTest, OutOfRangeLabel) {
+  TaskInfo task;
+  Resources totalSlaveResources;
+
+  // Add 50Mbps of network bandwidth by label.
+  Label* label = task.mutable_labels()->add_labels();
+  label->set_key(NETWORK_BANDWIDTH_RESOURCE_LABEL);
+  label->set_value("5000000000000000000000000000000000000000000000000000");
+
+  Try<Nothing> result = resources::enforceNetworkBandwidthAllocation(
+    totalSlaveResources, task);
+
+  ASSERT_ERROR(result);
+  ASSERT_EQ("Network bandwidth amount is out of range.", result.error());
+}
+
+
+// When a task does not declare any network bandwidth and the slave advertised
+//      some.
+// Then enforcement computes a default value based on share of CPUs and the
+//      pool of 2Gbps.
+TEST(MasterResourcesNetworkBandwidthTest, AddDefaultNetworkBandwidth) {
+  TaskInfo task;
+  Resources totalSlaveResources;
+
+  // Declare 100Mbps and 4 CPUs on the slave.
+  totalSlaveResources += NetworkBandwidth(100);
+  totalSlaveResources += CPU(4);
+
+  // Add 1 CPU to the task.
+  task.mutable_resources()->Add()->CopyFrom(CPU(1));
+
+  Try<Nothing> result = resources::enforceNetworkBandwidthAllocation(
+    totalSlaveResources, task);
+
+  ASSERT_SOME(result);
+  ASSERT_HAS_NETWORK_BANDWIDTH(task.resources(), NetworkBandwidth(500));
+}
+
+
+// When a task has no network bandwidth reservation and the slave does not
+// declare any either,
+// Then the task has a default value taken from 2Gbps pool.
+TEST(MasterResourcesNetworkBandwidthTest, SlaveDoesNotDeclareNetworkBandwidth) {
+  TaskInfo task;
+  Resources totalSlaveResources;
+
+  // Declare 4 CPUs but no network bandwidth on the slave.
+  totalSlaveResources += CPU(4);
+
+  // Add 1 CPU to the task.
+  task.mutable_resources()->Add()->CopyFrom(CPU(1));
+
+  Try<Nothing> result = resources::enforceNetworkBandwidthAllocation(
+    totalSlaveResources, task);
+
+  ASSERT_SOME(result);
+  ASSERT_HAS_NETWORK_BANDWIDTH(task.resources(), NetworkBandwidth(500));
+}
+
+
+// Given a slave does not declare any CPU
+// When enforcement mechanism tries to compute network bandwidth based on
+//      CPU shares
+// Then it raises an error.
+TEST(MasterResourcesNetworkBandwidthTest, SlaveHasNoCpu) {
+  TaskInfo task;
+  Resources totalSlaveResources;
+
+  totalSlaveResources += NetworkBandwidth(100);
+
+  // Reserve 1 CPU.
+  task.mutable_resources()->Add()->CopyFrom(CPU(1));
+
+  Try<Nothing> result = resources::enforceNetworkBandwidthAllocation(
+    totalSlaveResources, task);
+
+  ASSERT_ERROR(result);
+  ASSERT_EQ("No CPU advertised by the slave. " \
+            "Cannot deduce network bandwidth.", result.error());
+}
+
+
+// Given a task does not have declared CPU,
+// When enforcement mechanism tries to compute network bandwidth based on
+//      CPU shares,
+// Then it raises an error.
+TEST(MasterResourcesNetworkBandwidthTest, TaskHasNoCpu) {
+  TaskInfo task;
+  Resources totalSlaveResources;
+
+  totalSlaveResources += CPU(4);
+  totalSlaveResources += NetworkBandwidth(100);
+
+  Try<Nothing> result = resources::enforceNetworkBandwidthAllocation(
+    totalSlaveResources, task);
+
+  ASSERT_ERROR(result);
+  ASSERT_EQ("No CPU declared in the task. " \
+            "Cannot deduce network bandwidth.", result.error());
+}
+
+
+// Test case: we are protected from a division by zero when computing the
+//   share of CPUs because resources are filtered out when less than 0.0001.
+//   (see convertToFixed in src/common/values.cpp)
+//
+// Given a task declares 0 as amount of CPUs,
+// When enforcement mechanism tries to compute network bandwidth based on
+//      CPU shares,
+// Then it returns 0 for network bandwidth.
+TEST(MasterResourcesNetworkBandwidthTest, DivisonByZero) {
+  TaskInfo task;
+  Resources totalSlaveResources;
+
+  // Declare 0.00001 CPUs and 100Mbps of network bandwidth.
+  // The CPU is filtered out during the addition.
+  totalSlaveResources += CPU(0.00001);
+  totalSlaveResources += NetworkBandwidth(100);
+
+  // Add 0 CPU to the task.
+  task.mutable_resources()->Add()->CopyFrom(CPU(1));
+
+  Try<Nothing> result = resources::enforceNetworkBandwidthAllocation(
+    totalSlaveResources, task);
+
+  ASSERT_ERROR(result);
+  ASSERT_EQ("No CPU advertised by the slave. "\
+            "Cannot deduce network bandwidth.", result.error());
+}
+
+} // namespace tests {
+} // namespace internal {
+} // namespace mesos {


### PR DESCRIPTION
We make network bandwidth a first-class resource in Mesos. Therefore,
every task should have it declared when falling on a slave declaring
network bandwidth.
If task do not declare the reserved amount, Mesos reserves a default
amount taken out from the unreserved resources and related to
the share of reserved CPU.

In order to support every frameworks not supporting network bandwidth
yet, the resource can also be declared with a label called
NETWORK_BANDWIDTH_RESOURCE.

Note: This implementation only distributes unreserved resources. This
means that in nominal case, the scheduler can match offer for any role
if support for network bandwidth is correctly implemented. However, in the
case of labels and default value, the network bandwidth is automatically
taken from unreserved pool.