### PR TITLE
Http API returns 0 for network bandwidth.

### DIFF
--- a/src/master/flags.cpp
+++ b/src/master/flags.cpp
@@ -677,4 +677,9 @@ mesos::internal::master::Flags::Flags()
         }
         return None();
       });
+
+  add(&Flags::enable_network_bandwidth_enforcement,
+      "network_bandwidth_enforcement",
+      "Boolean enabling the network bandwidth enforcement\n",
+      false);
 }

--- a/src/master/flags.hpp
+++ b/src/master/flags.hpp
@@ -111,6 +111,7 @@ public:
   // Optional IP discover script that will set the Master IP.
   // If set, its output is expected to be a valid parseable IP string.
   Option<std::string> ip_discovery_command;
+  bool enable_network_bandwidth_enforcement;
 
 #ifdef ENABLE_PORT_MAPPING_ISOLATOR
   Option<size_t> max_executors_per_agent;

--- a/src/master/master.cpp
+++ b/src/master/master.cpp
@@ -4123,10 +4123,13 @@ void Master::accept(
               task.mutable_health_check()->set_type(HealthCheck::HTTP);
             }
           }
-          Try<Nothing> result = resources::enforceNetworkBandwidthAllocation(
-            slave->totalResources, task);
-          if(result.isError()) {
-            LOG(WARNING) << result.error();
+
+          if (flags.enable_network_bandwidth_enforcement) {
+            Try<Nothing> result = resources::enforceNetworkBandwidthAllocation(
+              slave->totalResources, task);
+            if(result.isError()) {
+              LOG(WARNING) << result.error();
+            }
           }
         }
 
@@ -4145,10 +4148,12 @@ void Master::accept(
           if (!task.has_executor()) {
             task.mutable_executor()->CopyFrom(executor);
           }
-          Try<Nothing> result = resources::enforceNetworkBandwidthAllocation(
-            slave->totalResources, task);
-          if(result.isError()) {
-            LOG(WARNING) << result.error();
+          if (flags.enable_network_bandwidth_enforcement) {
+            Try<Nothing> result = resources::enforceNetworkBandwidthAllocation(
+              slave->totalResources, task);
+            if(result.isError()) {
+              LOG(WARNING) << result.error();
+            }
           }
         }
 

--- a/src/tests/master_resources_network_bandwidth_tests.cpp
+++ b/src/tests/master_resources_network_bandwidth_tests.cpp
@@ -23,16 +23,6 @@
 #include <stout/gtest.hpp>
 
 namespace mesos {
-bool operator==(const Resource& left, const Resource& right)
-{
-  return left.name() == right.name()
-    && left.type() == right.type()
-    && left.scalar() == right.scalar()
-    && left.allocation_info().role() == right.allocation_info().role();
-}
-} // namespace mesos {
-
-namespace mesos {
 namespace internal {
 namespace tests {
 
@@ -64,7 +54,9 @@ void ASSERT_HAS_NETWORK_BANDWIDTH(
     ASSERT_TRUE(false) << "Network bandwidth should be present.";
   }
   else {
-    ASSERT_EQ(networkBandwidth.get(), expectedNetworkBandwidth);
+    ASSERT_EQ(
+      Resources(networkBandwidth.get()),
+      Resources(expectedNetworkBandwidth));
   }
 }
 


### PR DESCRIPTION
Before this fix disk and gpus had a value of 0 when querying
/slave/state and /master/state. The resource is actually not declared in
Mesos but the 0 value is added to the JSON when the API is queried.

In this commit we do the same for network bandwidth.