### PR TITLE
Additional fixes for network bandwidth

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2350,6 +2350,7 @@ mesos_tests_SOURCES =						\
   tests/master_contender_detector_tests.cpp			\
   tests/master_maintenance_tests.cpp				\
   tests/master_quota_tests.cpp					\
+  tests/master_network_bandwidth_scheduling_tests.cpp				\
   tests/master_resources_network_bandwidth_tests.cpp				\
   tests/master_slave_reconciliation_tests.cpp			\
   tests/master_tests.cpp					\

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1191,6 +1191,7 @@ libmesos_no_3rdparty_la_SOURCES +=					\
   tests/mock_slave.hpp							\
   tests/mock_registrar.hpp						\
   tests/module.hpp							\
+  tests/network_bandwidth_helper.hpp					\
   tests/resources_utils.hpp						\
   tests/script.hpp							\
   tests/utils.hpp							\
@@ -2165,6 +2166,7 @@ test_helper_SOURCES =						\
   tests/flags.cpp						\
   tests/http_server_test_helper.cpp				\
   tests/kill_policy_test_helper.cpp				\
+  tests/network_bandwidth_helper.cpp				\
   tests/resources_utils.cpp					\
   tests/test_helper_main.cpp					\
   tests/utils.cpp						\
@@ -2363,6 +2365,7 @@ mesos_tests_SOURCES =						\
   tests/mock_registrar.cpp					\
   tests/module.cpp						\
   tests/module_tests.cpp					\
+  tests/network_bandwidth_helper.cpp				\
   tests/oversubscription_tests.cpp				\
   tests/partition_tests.cpp					\
   tests/paths_tests.cpp						\

--- a/src/master/flags.cpp
+++ b/src/master/flags.cpp
@@ -677,4 +677,9 @@ mesos::internal::master::Flags::Flags()
         }
         return None();
       });
+
+  add(&Flags::network_bandwidth_enforcement,
+      "network_bandwidth_enforcement",
+      "Enable the network bandwidth enforcement.",
+      false);
 }

--- a/src/master/flags.hpp
+++ b/src/master/flags.hpp
@@ -111,6 +111,7 @@ public:
   // Optional IP discover script that will set the Master IP.
   // If set, its output is expected to be a valid parseable IP string.
   Option<std::string> ip_discovery_command;
+  bool network_bandwidth_enforcement;
 
 #ifdef ENABLE_PORT_MAPPING_ISOLATOR
   Option<size_t> max_executors_per_agent;

--- a/src/master/master.cpp
+++ b/src/master/master.cpp
@@ -4123,10 +4123,13 @@ void Master::accept(
               task.mutable_health_check()->set_type(HealthCheck::HTTP);
             }
           }
-          Try<Nothing> result = resources::enforceNetworkBandwidthAllocation(
-            slave->totalResources, task);
-          if(result.isError()) {
-            LOG(WARNING) << result.error();
+
+          if (flags.network_bandwidth_enforcement) {
+            Try<Nothing> result = resources::enforceNetworkBandwidthAllocation(
+              slave->totalResources, task);
+            if(result.isError()) {
+              LOG(WARNING) << result.error();
+            }
           }
         }
 
@@ -4145,10 +4148,12 @@ void Master::accept(
           if (!task.has_executor()) {
             task.mutable_executor()->CopyFrom(executor);
           }
-          Try<Nothing> result = resources::enforceNetworkBandwidthAllocation(
-            slave->totalResources, task);
-          if(result.isError()) {
-            LOG(WARNING) << result.error();
+          if (flags.network_bandwidth_enforcement) {
+            Try<Nothing> result = resources::enforceNetworkBandwidthAllocation(
+              slave->totalResources, task);
+            if(result.isError()) {
+              LOG(WARNING) << result.error();
+            }
           }
         }
 

--- a/src/master/resources/network_bandwidth.hpp
+++ b/src/master/resources/network_bandwidth.hpp
@@ -35,21 +35,28 @@ namespace resources {
  * scheduler via resources or labels. Otherwise it is computed and added to the
  * task. The computation is the following:
  *
- * TaskNetworkBandwidth = TaskCpus / SlaveCpus * SlaveNetworkBandwidth.
+ * TaskNetworkBandwidth = TaskCpus / SlaveCpus * 2000.
  *
  * This computation is definitely Criteo specific and could be anything else.
+ * 2000 is equivalent to 2Gbps which is the lowest common amount of network
+ * bandwidth available on each agent in the entire Criteo infrastructure.
+ * We set a constant here, for 2 reasons: backward compatibility and ensure
+ * two instances of the same app have the same limit.
+ *
+ * TODO(clems4ever): make this value customizable by flag.
  *
  * Note: this amount of network bandwidth is taken out from unreserved
  *       resources since we don't take roles into account yet.
  *
  * @param slaveTotalResources The resources declared on the slave.
- * @param task The task to enforce network bandwidth declaration for.
- * @return Nothing if enforcement is not applied or successful otherwise an
+ * @param operation The operation for which to enforce network bandwidth
+ *   reservation for.
+ * @return None if enforcement is not applied or successful otherwise an
  *         Error.
  */
-Try<Nothing> enforceNetworkBandwidthAllocation(
+Option<Error> enforceNetworkBandwidthAllocation(
   const Resources& slaveTotalResources,
-  TaskInfo& task);
+  Offer::Operation& operation);
 
 } // namespace resources {
 } // namespace mesos {

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ set(TEST_HELPER_SRC
   active_user_test_helper.cpp
   flags.cpp
   http_server_test_helper.cpp
+  network_bandwidth_helper.cpp
   resources_utils.cpp
   test_helper_main.cpp
   utils.cpp
@@ -62,6 +63,7 @@ set(MESOS_TESTS_UTILS_SRC
   mock_registrar.cpp
   mock_slave.cpp
   module.cpp
+  network_bandwidth_helper.cpp
   resources_utils.cpp
   utils.cpp
   containerizer/launcher.cpp

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -109,6 +109,7 @@ set(MESOS_TESTS_SRC
   http_authentication_tests.cpp
   http_fault_tolerance_tests.cpp
   master_maintenance_tests.cpp
+  master_network_bandwidth_scheduling_tests.cpp
   master_resources_network_bandwidth_tests.cpp
   master_slave_reconciliation_tests.cpp
   partition_tests.cpp

--- a/src/tests/master_network_bandwidth_scheduling_tests.cpp
+++ b/src/tests/master_network_bandwidth_scheduling_tests.cpp
@@ -1,0 +1,494 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+#include <vector>
+
+#include <gmock/gmock.h>
+
+#include "master/resources/network_bandwidth.hpp"
+
+#include <mesos/executor.hpp>
+#include <mesos/scheduler.hpp>
+
+#include <mesos/allocator/allocator.hpp>
+
+#include <mesos/scheduler/scheduler.hpp>
+
+#include <process/clock.hpp>
+#include <process/future.hpp>
+#include <process/gmock.hpp>
+#include <process/owned.hpp>
+
+#include "master/contender/zookeeper.hpp"
+
+#include "master/detector/standalone.hpp"
+
+#include "tests/containerizer.hpp"
+#include "tests/mesos.hpp"
+
+#include <stout/gtest.hpp>
+
+using mesos::master::detector::MasterDetector;
+using mesos::master::detector::StandaloneMasterDetector;
+
+using process::Clock;
+using process::Future;
+using process::Owned;
+using process::Promise;
+
+using std::string;
+using std::vector;
+
+using testing::DoAll;
+using testing::AtMost;
+
+namespace mesos {
+namespace internal {
+namespace tests {
+
+class MasterNetworkBandwidthSchedulingTest : public MesosTest {
+public:
+};
+
+namespace {
+
+// Helper function create any kind of unreserved resource.
+Resource createResource(const string& resourceName, double amount) {
+  Resource resource;
+  resource.set_name(resourceName);
+  resource.set_type(mesos::Value::SCALAR);
+  resource.mutable_scalar()->set_value(amount);
+  resource.mutable_allocation_info()->set_role("*");
+  return resource;
+}
+
+Resource CPU(double amount) {
+  return createResource("cpus", amount);
+}
+
+Resource NetworkBandwidth(double amount) {
+  return createResource("network_bandwidth", amount);
+}
+
+Resource Memory(double amount) {
+  return createResource("mem", amount);
+}
+
+} // namespace {
+
+// Given a task declares network bandwidth,
+// When it is scheduled,
+// Then it has a running status.
+TEST_F(MasterNetworkBandwidthSchedulingTest, TaskRunningWithNetworkBandwidth)
+{
+  Option<master::Flags> masterFlags = MesosTest::CreateMasterFlags();
+  masterFlags.get().network_bandwidth_enforcement = true;
+  Try<Owned<cluster::Master>> master = StartMaster(masterFlags);
+  ASSERT_SOME(master);
+
+  MockExecutor exec(DEFAULT_EXECUTOR_ID);
+  TestContainerizer containerizer(&exec);
+
+  Owned<MasterDetector> detector = master.get()->createDetector();
+  Option<slave::Flags> flags = MesosTest::CreateSlaveFlags();
+  flags.get().resources = "cpus:4;mem:1000;network_bandwidth:1000";
+  Try<Owned<cluster::Slave>> slave = StartSlave(
+    detector.get(),
+    &containerizer,
+    flags);
+
+  ASSERT_SOME(slave);
+
+  MockScheduler sched;
+  MesosSchedulerDriver driver(
+      &sched, DEFAULT_FRAMEWORK_INFO, master.get()->pid, DEFAULT_CREDENTIAL);
+
+  EXPECT_CALL(sched, registered(&driver, _, _));
+
+  Future<vector<Offer>> offers;
+  EXPECT_CALL(sched, resourceOffers(&driver, _))
+    .WillOnce(FutureArg<1>(&offers))
+    .WillRepeatedly(Return()); // Ignore subsequent offers.
+
+  driver.start();
+
+  AWAIT_READY(offers);
+  ASSERT_NE(0u, offers->size());
+
+  Resources taskDeclaredResources;
+  taskDeclaredResources += CPU(1);
+  taskDeclaredResources += Memory(100);
+  taskDeclaredResources += NetworkBandwidth(50);
+
+  TaskInfo task;
+  task.set_name("");
+  task.mutable_task_id()->set_value("1");
+  task.mutable_slave_id()->MergeFrom(offers.get()[0].slave_id());
+  task.mutable_resources()->MergeFrom(taskDeclaredResources);
+  task.mutable_executor()->MergeFrom(DEFAULT_EXECUTOR_INFO);
+
+  EXPECT_CALL(exec, registered(_, _, _, _));
+
+  EXPECT_CALL(exec, launchTask(_, _))
+    .WillOnce(SendStatusUpdateFromTask(TASK_RUNNING));
+
+  Future<Nothing> update;
+  EXPECT_CALL(containerizer,
+              update(_, taskDeclaredResources))
+    .WillOnce(DoAll(FutureSatisfy(&update),
+                    Return(Nothing())));
+
+  Future<TaskStatus> status;
+  EXPECT_CALL(sched, statusUpdate(&driver, _))
+    .WillOnce(FutureArg<1>(&status));
+
+  driver.launchTasks(offers.get()[0].id(), {task});
+
+  AWAIT_READY(status);
+  EXPECT_EQ(TASK_RUNNING, status->state());
+  EXPECT_TRUE(status->has_executor_id());
+  EXPECT_EQ(exec.id, status->executor_id());
+
+  AWAIT_READY(update);
+
+  EXPECT_CALL(exec, shutdown(_))
+    .Times(AtMost(1));
+
+  driver.stop();
+  driver.join();
+}
+
+// Given a task declares network bandwidth,
+// When a task declares more network bandwidth than the slave,
+// Then scheduler receives a TASK_ERROR status.
+TEST_F(MasterNetworkBandwidthSchedulingTest,
+       TaskErrorBecauseOfTooMuchNetworkBandwidth)
+{
+  Option<master::Flags> masterFlags = MesosTest::CreateMasterFlags();
+  masterFlags.get().network_bandwidth_enforcement = true;
+  Try<Owned<cluster::Master>> master = StartMaster(masterFlags);
+  ASSERT_SOME(master);
+
+  MockExecutor exec(DEFAULT_EXECUTOR_ID);
+  TestContainerizer containerizer(&exec);
+
+  Owned<MasterDetector> detector = master.get()->createDetector();
+  Option<slave::Flags> flags = MesosTest::CreateSlaveFlags();
+  flags.get().resources = "cpus:4;mem:1000;network_bandwidth:1000";
+  Try<Owned<cluster::Slave>> slave = StartSlave(
+    detector.get(),
+    &containerizer,
+    flags);
+
+  ASSERT_SOME(slave);
+
+  MockScheduler sched;
+  MesosSchedulerDriver driver(
+      &sched, DEFAULT_FRAMEWORK_INFO, master.get()->pid, DEFAULT_CREDENTIAL);
+
+  EXPECT_CALL(sched, registered(&driver, _, _));
+
+  Future<vector<Offer>> offers;
+  EXPECT_CALL(sched, resourceOffers(&driver, _))
+    .WillOnce(FutureArg<1>(&offers))
+    .WillRepeatedly(Return()); // Ignore subsequent offers.
+
+  driver.start();
+
+  AWAIT_READY(offers);
+  ASSERT_NE(0u, offers->size());
+
+  Resources taskDeclaredResources;
+  taskDeclaredResources += CPU(1);
+  taskDeclaredResources += Memory(100);
+  taskDeclaredResources += NetworkBandwidth(2000);
+
+  TaskInfo task;
+  task.set_name("");
+  task.mutable_task_id()->set_value("1");
+  task.mutable_slave_id()->MergeFrom(offers.get()[0].slave_id());
+  task.mutable_resources()->MergeFrom(taskDeclaredResources);
+  task.mutable_executor()->MergeFrom(DEFAULT_EXECUTOR_INFO);
+
+  Future<TaskStatus> status;
+  EXPECT_CALL(sched, statusUpdate(&driver, _))
+    .WillOnce(FutureArg<1>(&status));
+
+  driver.launchTasks(offers.get()[0].id(), {task});
+
+  AWAIT_READY(status);
+  EXPECT_EQ(TASK_ERROR, status->state());
+  EXPECT_TRUE(status->has_task_id());
+  EXPECT_EQ("1", status->task_id().value());
+  EXPECT_FALSE(status->has_executor_id());
+
+  driver.stop();
+  driver.join();
+}
+
+// Given a task declares network bandwidth in a label,
+// When it is scheduled,
+// Then it is provided with the amount declared in the label
+// And the task is running.
+TEST_F(MasterNetworkBandwidthSchedulingTest,
+       TaskRunningWithNetworkBandwidthInLabel)
+{
+  Option<master::Flags> masterFlags = MesosTest::CreateMasterFlags();
+  masterFlags.get().network_bandwidth_enforcement = true;
+  Try<Owned<cluster::Master>> master = StartMaster(masterFlags);
+  ASSERT_SOME(master);
+
+  MockExecutor exec(DEFAULT_EXECUTOR_ID);
+  TestContainerizer containerizer(&exec);
+
+  Owned<MasterDetector> detector = master.get()->createDetector();
+  Option<slave::Flags> flags = MesosTest::CreateSlaveFlags();
+  flags.get().resources = "cpus:4;mem:1000;network_bandwidth:1000";
+  Try<Owned<cluster::Slave>> slave = StartSlave(
+    detector.get(),
+    &containerizer,
+    flags);
+
+  ASSERT_SOME(slave);
+
+  MockScheduler sched;
+  MesosSchedulerDriver driver(
+      &sched, DEFAULT_FRAMEWORK_INFO, master.get()->pid, DEFAULT_CREDENTIAL);
+
+  EXPECT_CALL(sched, registered(&driver, _, _));
+
+  Future<vector<Offer>> offers;
+  EXPECT_CALL(sched, resourceOffers(&driver, _))
+    .WillOnce(FutureArg<1>(&offers))
+    .WillRepeatedly(Return()); // Ignore subsequent offers.
+
+  driver.start();
+
+  AWAIT_READY(offers);
+  ASSERT_NE(0u, offers->size());
+
+  Resources taskDeclaredResources;
+  taskDeclaredResources += CPU(1);
+  taskDeclaredResources += Memory(100);
+
+  Resources taskActualResources = taskDeclaredResources;
+  taskActualResources += NetworkBandwidth(20);
+
+  TaskInfo task;
+  task.set_name("");
+  task.mutable_task_id()->set_value("1");
+  task.mutable_slave_id()->MergeFrom(offers.get()[0].slave_id());
+  task.mutable_resources()->MergeFrom(taskDeclaredResources);
+  task.mutable_executor()->MergeFrom(DEFAULT_EXECUTOR_INFO);
+  mesos::Label* label = task.mutable_labels()->add_labels();
+  label->set_key("NETWORK_BANDWIDTH_RESOURCE");
+  label->set_value("20");
+
+  EXPECT_CALL(exec, registered(_, _, _, _));
+
+  EXPECT_CALL(exec, launchTask(_, _))
+    .WillOnce(SendStatusUpdateFromTask(TASK_RUNNING));
+
+  Future<Nothing> update;
+  EXPECT_CALL(containerizer,
+              update(_, taskActualResources))
+    .WillOnce(DoAll(FutureSatisfy(&update),
+                    Return(Nothing())));
+
+  Future<TaskStatus> status;
+  EXPECT_CALL(sched, statusUpdate(&driver, _))
+    .WillOnce(FutureArg<1>(&status));
+
+  driver.launchTasks(offers.get()[0].id(), {task});
+
+  AWAIT_READY(status);
+  EXPECT_EQ(TASK_RUNNING, status->state());
+  EXPECT_TRUE(status->has_executor_id());
+  EXPECT_EQ(exec.id, status->executor_id());
+
+  AWAIT_READY(update);
+
+  EXPECT_CALL(exec, shutdown(_))
+    .Times(AtMost(1));
+
+  driver.stop();
+  driver.join();
+}
+
+
+// Given a task declares network bandwidth in a label,
+// When the format is wrong,
+// Then the scheduler receives a TASK_ERROR status.
+TEST_F(MasterNetworkBandwidthSchedulingTest,
+       TaskErrorWithBadNetworkBandwidthInLabel)
+{
+  Option<master::Flags> masterFlags = MesosTest::CreateMasterFlags();
+  masterFlags.get().network_bandwidth_enforcement = true;
+  Try<Owned<cluster::Master>> master = StartMaster(masterFlags);
+  ASSERT_SOME(master);
+
+  MockExecutor exec(DEFAULT_EXECUTOR_ID);
+  TestContainerizer containerizer(&exec);
+
+  Owned<MasterDetector> detector = master.get()->createDetector();
+  Option<slave::Flags> flags = MesosTest::CreateSlaveFlags();
+  flags.get().resources = "cpus:4;mem:1000;network_bandwidth:1000";
+  Try<Owned<cluster::Slave>> slave = StartSlave(
+    detector.get(),
+    &containerizer,
+    flags);
+
+  ASSERT_SOME(slave);
+
+  MockScheduler sched;
+  MesosSchedulerDriver driver(
+      &sched, DEFAULT_FRAMEWORK_INFO, master.get()->pid, DEFAULT_CREDENTIAL);
+
+  EXPECT_CALL(sched, registered(&driver, _, _));
+
+  Future<vector<Offer>> offers;
+  EXPECT_CALL(sched, resourceOffers(&driver, _))
+    .WillOnce(FutureArg<1>(&offers))
+    .WillRepeatedly(Return()); // Ignore subsequent offers.
+
+  driver.start();
+
+  AWAIT_READY(offers);
+  ASSERT_NE(0u, offers->size());
+
+  Resources taskDeclaredResources;
+  taskDeclaredResources += CPU(1);
+  taskDeclaredResources += Memory(100);
+
+  TaskInfo task;
+  task.set_name("");
+  task.mutable_task_id()->set_value("1");
+  task.mutable_slave_id()->MergeFrom(offers.get()[0].slave_id());
+  task.mutable_resources()->MergeFrom(taskDeclaredResources);
+  task.mutable_executor()->MergeFrom(DEFAULT_EXECUTOR_INFO);
+  mesos::Label* label = task.mutable_labels()->add_labels();
+  label->set_key("NETWORK_BANDWIDTH_RESOURCE");
+  label->set_value("bad_20");
+
+  EXPECT_CALL(exec, registered(_, _, _, _));
+
+  EXPECT_CALL(exec, launchTask(_, _))
+    .WillOnce(SendStatusUpdateFromTask(TASK_RUNNING));
+
+  Future<TaskStatus> status;
+  EXPECT_CALL(sched, statusUpdate(&driver, _))
+    .WillOnce(FutureArg<1>(&status));
+
+  driver.launchTasks(offers.get()[0].id(), {task});
+
+  AWAIT_READY(status);
+  EXPECT_EQ(TASK_ERROR, status->state());
+  EXPECT_FALSE(status->has_executor_id());
+
+  driver.stop();
+  driver.join();
+}
+
+
+// Given a task does not declare network bandwidth,
+// When it is scheduled,
+// Then it is provided with a default value for network bandwidth
+// And the task is running.
+TEST_F(MasterNetworkBandwidthSchedulingTest, TaskRunningWithoutNetworkBandwidth)
+{
+  Option<master::Flags> masterFlags = MesosTest::CreateMasterFlags();
+  masterFlags.get().network_bandwidth_enforcement = true;
+  Try<Owned<cluster::Master>> master = StartMaster(masterFlags);
+  ASSERT_SOME(master);
+
+  MockExecutor exec(DEFAULT_EXECUTOR_ID);
+  TestContainerizer containerizer(&exec);
+
+  Owned<MasterDetector> detector = master.get()->createDetector();
+  Option<slave::Flags> flags = MesosTest::CreateSlaveFlags();
+  flags.get().resources = "cpus:4;mem:1000;network_bandwidth:1000";
+  Try<Owned<cluster::Slave>> slave = StartSlave(
+    detector.get(),
+    &containerizer,
+    flags);
+
+  ASSERT_SOME(slave);
+
+  MockScheduler sched;
+  MesosSchedulerDriver driver(
+      &sched, DEFAULT_FRAMEWORK_INFO, master.get()->pid, DEFAULT_CREDENTIAL);
+
+  EXPECT_CALL(sched, registered(&driver, _, _));
+
+  Future<vector<Offer>> offers;
+  EXPECT_CALL(sched, resourceOffers(&driver, _))
+    .WillOnce(FutureArg<1>(&offers))
+    .WillRepeatedly(Return()); // Ignore subsequent offers.
+
+  driver.start();
+
+  AWAIT_READY(offers);
+  ASSERT_NE(0u, offers->size());
+
+  Resources taskDeclaredResources;
+  taskDeclaredResources += CPU(1);
+  taskDeclaredResources += Memory(100);
+
+  Resources taskActualResources = taskDeclaredResources;
+  taskActualResources += NetworkBandwidth(500);
+
+  TaskInfo task;
+  task.set_name("");
+  task.mutable_task_id()->set_value("1");
+  task.mutable_slave_id()->MergeFrom(offers.get()[0].slave_id());
+  task.mutable_resources()->MergeFrom(taskDeclaredResources);
+  task.mutable_executor()->MergeFrom(DEFAULT_EXECUTOR_INFO);
+
+  EXPECT_CALL(exec, registered(_, _, _, _));
+
+  EXPECT_CALL(exec, launchTask(_, _))
+    .WillOnce(SendStatusUpdateFromTask(TASK_RUNNING));
+
+  Future<Nothing> update;
+  EXPECT_CALL(containerizer,
+              update(_, taskActualResources))
+    .WillOnce(DoAll(FutureSatisfy(&update),
+                    Return(Nothing())));
+
+  Future<TaskStatus> status;
+  EXPECT_CALL(sched, statusUpdate(&driver, _))
+    .WillOnce(FutureArg<1>(&status));
+
+  driver.launchTasks(offers.get()[0].id(), {task});
+
+  AWAIT_READY(status);
+  EXPECT_EQ(TASK_RUNNING, status->state());
+  EXPECT_TRUE(status->has_executor_id());
+  EXPECT_EQ(exec.id, status->executor_id());
+
+  AWAIT_READY(update);
+
+  EXPECT_CALL(exec, shutdown(_))
+    .Times(AtMost(1));
+
+  driver.stop();
+  driver.join();
+}
+
+} // namespace tests {
+} // namespace internal {
+} // namespace mesos {

--- a/src/tests/master_resources_network_bandwidth_tests.cpp
+++ b/src/tests/master_resources_network_bandwidth_tests.cpp
@@ -32,6 +32,8 @@ const string NETWORK_BANDWIDTH_RESOURCE_LABEL = "NETWORK_BANDWIDTH_RESOURCE";
 const string NETWORK_BANDWIDTH_RESOURCE_NAME = "network_bandwidth";
 const string CPUS_RESOURCE_NAME = "cpus";
 
+namespace {
+
 Option<Resource> getUnreservedResource(
     const Resources& resources,
     const string& resourceName) {
@@ -87,6 +89,8 @@ Resource CPU(double amount) {
 Resource NetworkBandwidth(double amount) {
   return createResource(NETWORK_BANDWIDTH_RESOURCE_NAME, amount);
 }
+
+} // namespace {
 
 // Given a task has declared network bandwidth
 // Then enforcement should let the task goes through without update.

--- a/src/tests/master_resources_network_bandwidth_tests.cpp
+++ b/src/tests/master_resources_network_bandwidth_tests.cpp
@@ -23,16 +23,6 @@
 #include <stout/gtest.hpp>
 
 namespace mesos {
-bool operator==(const Resource& left, const Resource& right)
-{
-  return left.name() == right.name()
-    && left.type() == right.type()
-    && left.scalar() == right.scalar()
-    && left.allocation_info().role() == right.allocation_info().role();
-}
-} // namespace mesos {
-
-namespace mesos {
 namespace internal {
 namespace tests {
 
@@ -64,7 +54,9 @@ void ASSERT_HAS_NETWORK_BANDWIDTH(
     ASSERT_TRUE(false) << "Network bandwidth should be present.";
   }
   else {
-    ASSERT_EQ(networkBandwidth.get(), expectedNetworkBandwidth);
+    ASSERT_EQ(
+      Resources(networkBandwidth.get()),
+      Resources(expectedNetworkBandwidth));
   }
 }
 

--- a/src/tests/network_bandwidth_helper.cpp
+++ b/src/tests/network_bandwidth_helper.cpp
@@ -1,0 +1,55 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
+#include "tests/network_bandwidth_helper.hpp"
+
+#include <string>
+
+#include <mesos/resources.hpp>
+
+namespace mesos {
+namespace internal {
+namespace tests {
+namespace resources {
+
+// Helper function create any kind of unreserved resource.
+mesos::Resource createResource(
+  const std::string& resourceName,
+  double amount) {
+  mesos::Resource resource;
+  resource.set_name(resourceName);
+  resource.set_type(mesos::Value::SCALAR);
+  resource.mutable_scalar()->set_value(amount);
+  resource.mutable_allocation_info()->set_role("*");
+  return resource;
+}
+
+mesos::Resource CPU(double amount) {
+  return createResource("cpus", amount);
+}
+
+mesos::Resource NetworkBandwidth(double amount) {
+  return createResource("network_bandwidth", amount);
+}
+
+mesos::Resource Memory(double amount) {
+  return createResource("mem", amount);
+}
+
+} // namespace resources {
+} // namespace tests {
+} // namespace internal {
+} // namespace mesos {

--- a/src/tests/network_bandwidth_helper.hpp
+++ b/src/tests/network_bandwidth_helper.hpp
@@ -1,0 +1,43 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
+#ifndef __TESTS_NETWORK_BANDWIDTH_HELPER_HPP__
+#define __TESTS_NETWORK_BANDWIDTH_HELPER_HPP__
+
+#include <string>
+
+#include <mesos/resources.hpp>
+
+namespace mesos {
+namespace internal {
+namespace tests {
+namespace resources {
+
+const std::string NETWORK_BANDWIDTH_RESOURCE_LABEL =
+    "NETWORK_BANDWIDTH_RESOURCE";
+const std::string NETWORK_BANDWIDTH_RESOURCE_NAME = "network_bandwidth";
+const std::string CPUS_RESOURCE_NAME = "cpus";
+
+mesos::Resource CPU(double amount);
+mesos::Resource NetworkBandwidth(double amount);
+mesos::Resource Memory(double amount);
+
+} // namespace resources {
+} // namespace tests {
+} // namespace internal {
+} // namespace mesos {
+
+#endif


### PR DESCRIPTION
Add flag to enable network bandwidth enforcement and fix unit tests.

Please note that for building the RPM, we need to regenerate Makefile.in files with automake and append the changes from this file to the patch in the RPM. Otherwise, the builder will try to use automake 1.15 to regenerate Makefile.in but this version is not on the builders.