### PR TITLE
Allocate network bandwidth to the same role as other task resources.

### DIFF
--- a/src/tests/master_resources_network_bandwidth_tests.cpp
+++ b/src/tests/master_resources_network_bandwidth_tests.cpp
@@ -61,16 +61,6 @@ void ASSERT_HAS_NETWORK_BANDWIDTH(
   }
 }
 
-void ASSERT_HAS_NO_NETWORK_BANDWIDTH(
-  const Resources& resources) {
-  Option<Resource> networkBandwidth = getUnreservedResource(
-    resources, resources::NETWORK_BANDWIDTH_RESOURCE_NAME);
-
-  if(networkBandwidth.isSome()) {
-    ASSERT_TRUE(false) << "There should not be any declared network bandwidth.";
-  }
-}
-
 } // namespace {
 
 // Given a task has declared network bandwidth
@@ -245,7 +235,7 @@ TEST(MasterResourcesNetworkBandwidthTest, SlaveHasNoCpu) {
 TEST(MasterResourcesNetworkBandwidthTest, TaskHasNoCpu) {
   Offer::Operation operation;
   operation.set_type(Offer::Operation::LAUNCH);
-  TaskInfo* taskInfo = operation.mutable_launch()->add_task_infos();
+  operation.mutable_launch()->add_task_infos();
   Resources totalSlaveResources;
 
   totalSlaveResources += resources::CPU(4);

--- a/src/tests/network_bandwidth_helper.cpp
+++ b/src/tests/network_bandwidth_helper.cpp
@@ -28,25 +28,26 @@ namespace resources {
 // Helper function create any kind of unreserved resource.
 mesos::Resource createResource(
   const std::string& resourceName,
-  double amount) {
+  double amount,
+  const std::string& role) {
   mesos::Resource resource;
   resource.set_name(resourceName);
   resource.set_type(mesos::Value::SCALAR);
   resource.mutable_scalar()->set_value(amount);
-  resource.mutable_allocation_info()->set_role("*");
+  resource.mutable_allocation_info()->set_role(role);
   return resource;
 }
 
-mesos::Resource CPU(double amount) {
-  return createResource("cpus", amount);
+mesos::Resource CPU(double amount, const std::string& role) {
+  return createResource("cpus", amount, role);
 }
 
-mesos::Resource NetworkBandwidth(double amount) {
-  return createResource("network_bandwidth", amount);
+mesos::Resource NetworkBandwidth(double amount, const std::string& role) {
+  return createResource("network_bandwidth", amount, role);
 }
 
-mesos::Resource Memory(double amount) {
-  return createResource("mem", amount);
+mesos::Resource Memory(double amount, const std::string& role) {
+  return createResource("mem", amount, role);
 }
 
 } // namespace resources {

--- a/src/tests/network_bandwidth_helper.hpp
+++ b/src/tests/network_bandwidth_helper.hpp
@@ -31,9 +31,9 @@ const std::string NETWORK_BANDWIDTH_RESOURCE_LABEL =
 const std::string NETWORK_BANDWIDTH_RESOURCE_NAME = "network_bandwidth";
 const std::string CPUS_RESOURCE_NAME = "cpus";
 
-mesos::Resource CPU(double amount);
-mesos::Resource NetworkBandwidth(double amount);
-mesos::Resource Memory(double amount);
+mesos::Resource CPU(double amount, const std::string& role = "*");
+mesos::Resource NetworkBandwidth(double amount, const std::string& role = "*");
+mesos::Resource Memory(double amount, const std::string& role = "*");
 
 } // namespace resources {
 } // namespace tests {


### PR DESCRIPTION
The role from the allocation_info in task resources must be same for
all resources of the task.
Otherwise the task is not scheduled and the scheduler is reporting the
following error:

```
Invalid task resources: The resources have multiple allocation roles
('*' and 'default') but only one allocation role is allowed
```

Also fixes some compilation issues in RPM. I had some unused variables warnings treated as errors by Makefiles and not by CMake.