### PR TITLE
Fix crashed due to bad role allocation for network bandwidth.

### DIFF
--- a/src/tests/master_network_bandwidth_scheduling_tests.cpp
+++ b/src/tests/master_network_bandwidth_scheduling_tests.cpp
@@ -19,6 +19,8 @@
 
 #include <gmock/gmock.h>
 
+#include <google/protobuf/repeated_field.h>
+
 #include "master/resources/network_bandwidth.hpp"
 
 #include <mesos/executor.hpp>
@@ -43,6 +45,8 @@
 
 #include <stout/gtest.hpp>
 
+using google::protobuf::RepeatedPtrField;
+
 using mesos::master::detector::MasterDetector;
 using mesos::master::detector::StandaloneMasterDetector;
 
@@ -62,6 +66,19 @@ namespace internal {
 namespace tests {
 
 class MasterNetworkBandwidthSchedulingTest : public MesosTest {};
+
+RepeatedPtrField<Resource> allocateTo(
+  const RepeatedPtrField<Resource>& resources,
+  const std::string& allocationRole) {
+  RepeatedPtrField<Resource> allocatedResources;
+  foreach(const Resource& resource, resources) {
+    Resource r(resource);
+    r.clear_role();
+    r.mutable_allocation_info()->set_role(allocationRole);
+    allocatedResources.Add()->CopyFrom(r);
+  }
+  return allocatedResources;
+}
 
 // Given a task declares network bandwidth,
 // When the task is scheduled,
@@ -102,16 +119,19 @@ TEST_F(MasterNetworkBandwidthSchedulingTest, TaskRunningWithNetworkBandwidth)
   AWAIT_READY(offers);
   ASSERT_NE(0u, offers->size());
 
-  Resources taskDeclaredResources;
-  taskDeclaredResources += resources::CPU(1);
-  taskDeclaredResources += resources::Memory(100);
-  taskDeclaredResources += resources::NetworkBandwidth(50);
+  RepeatedPtrField<Resource> reservedResources;
+  reservedResources.Add()->CopyFrom(resources::CPU(1));
+  reservedResources.Add()->CopyFrom(resources::Memory(100));
+  reservedResources.Add()->CopyFrom(resources::NetworkBandwidth(100));
+
+  RepeatedPtrField<Resource> allocatedResources =
+    allocateTo(reservedResources, "*");
 
   TaskInfo task;
   task.set_name("");
   task.mutable_task_id()->set_value("1");
   task.mutable_slave_id()->MergeFrom(offers.get()[0].slave_id());
-  task.mutable_resources()->MergeFrom(taskDeclaredResources);
+  task.mutable_resources()->MergeFrom(reservedResources);
   task.mutable_executor()->MergeFrom(DEFAULT_EXECUTOR_INFO);
 
   EXPECT_CALL(exec, registered(_, _, _, _));
@@ -121,7 +141,7 @@ TEST_F(MasterNetworkBandwidthSchedulingTest, TaskRunningWithNetworkBandwidth)
 
   Future<Nothing> update;
   EXPECT_CALL(containerizer,
-              update(_, taskDeclaredResources))
+              update(_, Resources(allocatedResources)))
     .WillOnce(DoAll(FutureSatisfy(&update),
                     Return(Nothing())));
 
@@ -185,16 +205,16 @@ TEST_F(MasterNetworkBandwidthSchedulingTest,
   AWAIT_READY(offers);
   ASSERT_NE(0u, offers->size());
 
-  Resources taskDeclaredResources;
-  taskDeclaredResources += resources::CPU(1);
-  taskDeclaredResources += resources::Memory(100);
-  taskDeclaredResources += resources::NetworkBandwidth(2000);
+  RepeatedPtrField<Resource> reservedResources;
+  reservedResources.Add()->CopyFrom(resources::CPU(1));
+  reservedResources.Add()->CopyFrom(resources::Memory(100));
+  reservedResources.Add()->CopyFrom(resources::NetworkBandwidth(2000));
 
   TaskInfo task;
   task.set_name("");
   task.mutable_task_id()->set_value("1");
   task.mutable_slave_id()->MergeFrom(offers.get()[0].slave_id());
-  task.mutable_resources()->MergeFrom(taskDeclaredResources);
+  task.mutable_resources()->MergeFrom(reservedResources);
   task.mutable_executor()->MergeFrom(DEFAULT_EXECUTOR_INFO);
 
   Future<TaskStatus> status;
@@ -254,18 +274,21 @@ TEST_F(MasterNetworkBandwidthSchedulingTest,
   AWAIT_READY(offers);
   ASSERT_NE(0u, offers->size());
 
-  Resources taskDeclaredResources;
-  taskDeclaredResources += resources::CPU(1);
-  taskDeclaredResources += resources::Memory(100);
+  RepeatedPtrField<Resource> reservedResources;
+  reservedResources.Add()->CopyFrom(resources::CPU(1));
+  reservedResources.Add()->CopyFrom(resources::Memory(100));
 
-  Resources taskActualResources = taskDeclaredResources;
-  taskActualResources += resources::NetworkBandwidth(20);
+  RepeatedPtrField<Resource> actualResources(reservedResources);
+  actualResources.Add()->CopyFrom(resources::NetworkBandwidth(20));
+
+  RepeatedPtrField<Resource> allocatedResources =
+    allocateTo(actualResources, "*");
 
   TaskInfo task;
   task.set_name("");
   task.mutable_task_id()->set_value("1");
   task.mutable_slave_id()->MergeFrom(offers.get()[0].slave_id());
-  task.mutable_resources()->MergeFrom(taskDeclaredResources);
+  task.mutable_resources()->MergeFrom(reservedResources);
   task.mutable_executor()->MergeFrom(DEFAULT_EXECUTOR_INFO);
   mesos::Label* label = task.mutable_labels()->add_labels();
   label->set_key(resources::NETWORK_BANDWIDTH_RESOURCE_LABEL);
@@ -278,7 +301,7 @@ TEST_F(MasterNetworkBandwidthSchedulingTest,
 
   Future<Nothing> update;
   EXPECT_CALL(containerizer,
-              update(_, taskActualResources))
+              update(_, Resources(allocatedResources)))
     .WillOnce(DoAll(FutureSatisfy(&update),
                     Return(Nothing())));
 
@@ -343,16 +366,17 @@ TEST_F(MasterNetworkBandwidthSchedulingTest,
   AWAIT_READY(offers);
   ASSERT_NE(0u, offers->size());
 
-  Resources taskDeclaredResources;
-  taskDeclaredResources += resources::CPU(1);
-  taskDeclaredResources += resources::Memory(100);
+  RepeatedPtrField<Resource> reservedResources;
+  reservedResources.Add()->CopyFrom(resources::CPU(1));
+  reservedResources.Add()->CopyFrom(resources::Memory(100));
 
   TaskInfo task;
   task.set_name("");
   task.mutable_task_id()->set_value("1");
   task.mutable_slave_id()->MergeFrom(offers.get()[0].slave_id());
-  task.mutable_resources()->MergeFrom(taskDeclaredResources);
+  task.mutable_resources()->MergeFrom(reservedResources);
   task.mutable_executor()->MergeFrom(DEFAULT_EXECUTOR_INFO);
+
   mesos::Label* label = task.mutable_labels()->add_labels();
   label->set_key(resources::NETWORK_BANDWIDTH_RESOURCE_LABEL);
   label->set_value("bad_20");
@@ -412,18 +436,22 @@ TEST_F(MasterNetworkBandwidthSchedulingTest, TaskRunningWithoutNetworkBandwidth)
   AWAIT_READY(offers);
   ASSERT_NE(0u, offers->size());
 
-  Resources taskDeclaredResources;
-  taskDeclaredResources += resources::CPU(1);
-  taskDeclaredResources += resources::Memory(100);
+  RepeatedPtrField<Resource> reservedResources;
+  reservedResources.Add()->CopyFrom(resources::CPU(1));
+  reservedResources.Add()->CopyFrom(resources::Memory(100));
 
-  Resources taskActualResources = taskDeclaredResources;
-  taskActualResources += resources::NetworkBandwidth(500);
+  RepeatedPtrField<Resource> actualResources(reservedResources);
+  actualResources.Add()->CopyFrom(resources::NetworkBandwidth(500));
+
+  RepeatedPtrField<Resource> allocatedResources = allocateTo(
+    actualResources, "*");
+
 
   TaskInfo task;
   task.set_name("");
   task.mutable_task_id()->set_value("1");
   task.mutable_slave_id()->MergeFrom(offers.get()[0].slave_id());
-  task.mutable_resources()->MergeFrom(taskDeclaredResources);
+  task.mutable_resources()->MergeFrom(reservedResources);
   task.mutable_executor()->MergeFrom(DEFAULT_EXECUTOR_INFO);
 
   EXPECT_CALL(exec, registered(_, _, _, _));
@@ -433,7 +461,103 @@ TEST_F(MasterNetworkBandwidthSchedulingTest, TaskRunningWithoutNetworkBandwidth)
 
   Future<Nothing> update;
   EXPECT_CALL(containerizer,
-              update(_, taskActualResources))
+              update(_, Resources(allocatedResources)))
+    .WillOnce(DoAll(FutureSatisfy(&update),
+                    Return(Nothing())));
+
+  Future<TaskStatus> status;
+  EXPECT_CALL(sched, statusUpdate(&driver, _))
+    .WillOnce(FutureArg<1>(&status));
+
+  driver.launchTasks(offers.get()[0].id(), {task});
+
+  AWAIT_READY(status);
+  EXPECT_EQ(TASK_RUNNING, status->state());
+  EXPECT_TRUE(status->has_executor_id());
+  EXPECT_EQ(exec.id, status->executor_id());
+
+  AWAIT_READY(update);
+
+  EXPECT_CALL(exec, shutdown(_))
+    .Times(AtMost(1));
+
+  driver.stop();
+  driver.join();
+}
+
+// Given the scheduler subscribes to role 'toto'
+// And the scheduler schedules a task that does not declare network bandwidth
+// When the task is scheduled,
+// Then the task is provided with a default value for network bandwidth
+// And the role for its resources is 'toto'
+// And the scheduler reports the task is running.
+TEST_F(MasterNetworkBandwidthSchedulingTest,
+       TaskRunningWithoutNetworkBandwidthButCustomRole)
+{
+  Option<master::Flags> masterFlags = MesosTest::CreateMasterFlags();
+  masterFlags.get().network_bandwidth_enforcement = true;
+  Try<Owned<cluster::Master>> master = StartMaster(masterFlags);
+  ASSERT_SOME(master);
+
+  MockExecutor exec(DEFAULT_EXECUTOR_ID);
+  TestContainerizer containerizer(&exec);
+
+  Owned<MasterDetector> detector = master.get()->createDetector();
+  Option<slave::Flags> flags = MesosTest::CreateSlaveFlags();
+  flags.get().resources = "cpus:4;mem:1000;network_bandwidth:1000";
+  Try<Owned<cluster::Slave>> slave = StartSlave(
+    detector.get(),
+    &containerizer,
+    flags);
+
+  ASSERT_SOME(slave);
+
+  // Make framework subscribe to role 'toto'.
+  FrameworkInfo frameworkInfo = DEFAULT_FRAMEWORK_INFO;
+  frameworkInfo.set_role("toto");
+
+  MockScheduler sched;
+  MesosSchedulerDriver driver(
+      &sched, frameworkInfo, master.get()->pid, DEFAULT_CREDENTIAL);
+
+  EXPECT_CALL(sched, registered(&driver, _, _));
+
+  Future<vector<Offer>> offers;
+  EXPECT_CALL(sched, resourceOffers(&driver, _))
+    .WillOnce(FutureArg<1>(&offers))
+    .WillRepeatedly(Return()); // Ignore subsequent offers.
+
+  driver.start();
+
+  AWAIT_READY(offers);
+  ASSERT_NE(0u, offers->size());
+
+  RepeatedPtrField<Resource> reservedResources;
+  reservedResources.Add()->CopyFrom(resources::CPU(1));
+  reservedResources.Add()->CopyFrom(resources::Memory(100));
+
+  RepeatedPtrField<Resource> actualResources(reservedResources);
+  actualResources.Add()->CopyFrom(resources::NetworkBandwidth(500));
+
+  RepeatedPtrField<Resource> allocatedResources = allocateTo(
+    actualResources, "toto");
+
+  TaskInfo task;
+  task.set_name("");
+  task.mutable_task_id()->set_value("1");
+  task.mutable_slave_id()->MergeFrom(offers.get()[0].slave_id());
+  task.mutable_resources()->MergeFrom(reservedResources);
+  task.mutable_executor()->MergeFrom(DEFAULT_EXECUTOR_INFO);
+
+  EXPECT_CALL(exec, registered(_, _, _, _));
+
+  EXPECT_CALL(exec, launchTask(_, _))
+    .WillOnce(SendStatusUpdateFromTask(TASK_RUNNING));
+
+  Future<Nothing> update;
+  // Here we check all resources have been allocated to role 'toto'.
+  EXPECT_CALL(containerizer,
+              update(_, Resources(allocatedResources)))
     .WillOnce(DoAll(FutureSatisfy(&update),
                     Return(Nothing())));
 

--- a/src/tests/network_bandwidth_helper.cpp
+++ b/src/tests/network_bandwidth_helper.cpp
@@ -34,19 +34,27 @@ mesos::Resource createResource(
   resource.set_name(resourceName);
   resource.set_type(mesos::Value::SCALAR);
   resource.mutable_scalar()->set_value(amount);
-  resource.mutable_allocation_info()->set_role(role);
+  if (!role.empty()) {
+    resource.set_role(role);
+  }
   return resource;
 }
 
-mesos::Resource CPU(double amount, const std::string& role) {
+mesos::Resource CPU(
+  double amount,
+  const std::string& role) {
   return createResource("cpus", amount, role);
 }
 
-mesos::Resource NetworkBandwidth(double amount, const std::string& role) {
+mesos::Resource NetworkBandwidth(
+  double amount,
+  const std::string& role) {
   return createResource("network_bandwidth", amount, role);
 }
 
-mesos::Resource Memory(double amount, const std::string& role) {
+mesos::Resource Memory(
+  double amount,
+  const std::string& role) {
   return createResource("mem", amount, role);
 }
 

--- a/src/tests/network_bandwidth_helper.hpp
+++ b/src/tests/network_bandwidth_helper.hpp
@@ -31,9 +31,17 @@ const std::string NETWORK_BANDWIDTH_RESOURCE_LABEL =
 const std::string NETWORK_BANDWIDTH_RESOURCE_NAME = "network_bandwidth";
 const std::string CPUS_RESOURCE_NAME = "cpus";
 
-mesos::Resource CPU(double amount, const std::string& role = "*");
-mesos::Resource NetworkBandwidth(double amount, const std::string& role = "*");
-mesos::Resource Memory(double amount, const std::string& role = "*");
+mesos::Resource CPU(
+  double amount,
+  const std::string& role = std::string());
+
+mesos::Resource NetworkBandwidth(
+  double amount,
+  const std::string& role = std::string());
+
+mesos::Resource Memory(
+  double amount,
+  const std::string& role = std::string());
 
 } // namespace resources {
 } // namespace tests {


### PR DESCRIPTION
Network bandwidth resource is appended in pre-reservation-refinement
format before being validated and normalized in
post-reservation-refinement format just after the network bandwidth
enforcement.

The crashes were due to the use of Resources class while
using pre-reservation-refinement resources which is not supposed to
happen.

Also, the allocation_info attribute of resources is meant to be set by
Mesos and has been introduced to support multi-role capability for
schedulers.