### PR TITLE
Display network bandwidth in Gbps instead of Mbps.

### DIFF
--- a/src/webui/master/static/agent.html
+++ b/src/webui/master/static/agent.html
@@ -194,7 +194,7 @@
           <td>{{state.unreserved_resources_allocated.gpus | number}} / {{state.unreserved_resources.gpus | number}}</td>
           <td>{{state.unreserved_resources_allocated.mem * (1024 * 1024) | dataSize}} / {{state.unreserved_resources.mem * (1024 * 1024) | dataSize}}</td>
           <td>{{state.unreserved_resources_allocated.disk * (1024 * 1024) | dataSize}} / {{state.unreserved_resources.disk * (1024 * 1024) | dataSize}}</td>
-          <td>{{state.unreserved_resources_allocated.network_bandwidth | bandwidth}} / {{state.unreserved_resources.network_bandwidth | bandwidth}}</td>
+          <td>{{state.unreserved_resources_allocated.network_bandwidth | bandwidthEmpty}} / {{state.unreserved_resources.network_bandwidth | bandwidthEmpty}}</td>
         </tr>
         <tr ng-repeat="reservation in $data">
           <td>{{reservation.role}}</td>
@@ -202,7 +202,7 @@
           <td>{{(state.reserved_resources_allocated[reservation.role].gpus || 0) | number}} / {{reservation.gpus | number}}</td>
           <td>{{(state.reserved_resources_allocated[reservation.role].mem * (1024 * 1024) || 0) | dataSize}} / {{reservation.mem * (1024 * 1024) | dataSize}}</td>
           <td>{{(state.reserved_resources_allocated[reservation.role].disk * (1024 * 1024) || 0) | dataSize}} / {{reservation.disk * (1024 * 1024) | dataSize}}</td>
-          <td>{{(state.reserved_resources_allocated[reservation.role].network_bandwidth || 0) | bandwidth}} / {{reservation.network_bandwidth | bandwidth}}</td>
+          <td>{{(state.reserved_resources_allocated[reservation.role].network_bandwidth || 0) | bandwidthEmpty}} / {{reservation.network_bandwidth | bandwidthEmpty}}</td>
         </tr>
       </tbody>
     </table>

--- a/src/webui/master/static/js/app.js
+++ b/src/webui/master/static/js/app.js
@@ -126,15 +126,17 @@
     })
     .filter('bandwidth', function() {
       return function(num) {
-        var rounded_num = num ? parseFloat(num.toFixed(4)).toString() : 0
-        return '' + rounded_num + ' Mbps';
+        var amount = num
+          ? (parseFloat(num) / 1000.0).toFixed(2).toString()
+          : '0';
+        return amount + ' Gbps';
       }
     })
     .filter('bandwidthEmpty', function() {
       return function(num) {
         if (num) {
-          var rounded_num = parseFloat(num.toFixed(4)).toString();
-          return '' + rounded_num + ' Mbps';
+          var amount = (parseFloat(num) / 1000.0).toFixed(2).toString()
+          return amount + ' Gbps';
         }
         return '';
       }


### PR DESCRIPTION
Also reduce the number of decimal digits to 2 to have a granularity of
10 Mbps.

And fixes a display issue in agent.html.