### PR TITLE
Http API returns 0 for network bandwidth.

### DIFF
--- a/src/common/http.cpp
+++ b/src/common/http.cpp
@@ -174,6 +174,7 @@ JSON::Object model(const Resources& resources)
   object.values["gpus"] = 0;
   object.values["mem"] = 0;
   object.values["disk"] = 0;
+  object.values["network_bandwidth"] = 0;
 
   // Model non-revocable resources.
   Resources nonRevocable = resources.nonRevocable();
@@ -636,7 +637,8 @@ static void json(JSON::ObjectWriter* writer, const NetworkInfo& info)
 void json(JSON::ObjectWriter* writer, const Resources& resources)
 {
   hashmap<string, double> scalars =
-    {{"cpus", 0}, {"gpus", 0}, {"mem", 0}, {"disk", 0}};
+    {{"cpus", 0}, {"gpus", 0}, {"mem", 0}, {"disk", 0},
+     {"network_bandwidth", 0}};
   hashmap<string, Value::Ranges> ranges;
   hashmap<string, Value::Set> sets;
 


### PR DESCRIPTION
Before this fix disk and gpus had a value of 0 when querying
/slave/state and /master/state. The resource is actually not declared in
Mesos but the 0 value is added to the JSON when the API is queried.

In this commit we do the same for network bandwidth.