### PR TITLE
Expose metrics about network_bandwidth in mesos endpoints.

### DIFF
--- a/src/master/metrics.cpp
+++ b/src/master/metrics.cpp
@@ -297,7 +297,9 @@ Metrics::Metrics(const Master& master)
   // Create resource gauges.
   // TODO(dhamon): Set these up dynamically when adding a slave based on the
   // resources the slave exposes.
-  const string resources[] = {"cpus", "gpus", "mem", "disk"};
+  const string resources[] = {
+    "cpus", "gpus", "mem", "disk", "network_bandwidth"
+  };
 
   foreach (const string& resource, resources) {
     Gauge total(

--- a/src/slave/metrics.cpp
+++ b/src/slave/metrics.cpp
@@ -130,7 +130,9 @@ Metrics::Metrics(const Slave& slave)
   // Create resource gauges.
   // TODO(dhamon): Set these up dynamically when creating a slave
   // based on the resources it exposes.
-  const string resources[] = {"cpus", "gpus", "mem", "disk"};
+  const string resources[] = {
+    "cpus", "gpus", "mem", "disk", "network_bandwidth"
+  };
 
   foreach (const string& resource, resources) {
     Gauge total(

--- a/src/tests/master_tests.cpp
+++ b/src/tests/master_tests.cpp
@@ -2348,6 +2348,17 @@ TEST_F(MasterTest, MetricsInMetricsEndpoint)
   EXPECT_EQ(1u, snapshot.values.count("master/disk_revocable_used"));
   EXPECT_EQ(1u, snapshot.values.count("master/disk_revocable_percent"));
 
+  EXPECT_EQ(1u, snapshot.values.count("master/network_bandwidth_total"));
+  EXPECT_EQ(1u, snapshot.values.count("master/network_bandwidth_used"));
+  EXPECT_EQ(1u, snapshot.values.count("master/network_bandwidth_percent"));
+
+  EXPECT_EQ(1u, snapshot.values.count(
+      "master/network_bandwidth_revocable_total"));
+  EXPECT_EQ(1u, snapshot.values.count(
+      "master/network_bandwidth_revocable_used"));
+  EXPECT_EQ(1u, snapshot.values.count(
+      "master/network_bandwidth_revocable_percent"));
+
   // Registrar Metrics.
   EXPECT_EQ(1u, snapshot.values.count("registrar/queued_operations"));
   EXPECT_EQ(1u, snapshot.values.count("registrar/registry_size_bytes"));

--- a/src/tests/slave_tests.cpp
+++ b/src/tests/slave_tests.cpp
@@ -1399,6 +1399,17 @@ TEST_F(SlaveTest, MetricsInMetricsEndpoint)
   EXPECT_EQ(1u, snapshot.values.count("slave/disk_revocable_total"));
   EXPECT_EQ(1u, snapshot.values.count("slave/disk_revocable_used"));
   EXPECT_EQ(1u, snapshot.values.count("slave/disk_revocable_percent"));
+
+  EXPECT_EQ(1u, snapshot.values.count("slave/network_bandwidth_total"));
+  EXPECT_EQ(1u, snapshot.values.count("slave/network_bandwidth_used"));
+  EXPECT_EQ(1u, snapshot.values.count("slave/network_bandwidth_percent"));
+
+  EXPECT_EQ(1u, snapshot.values.count(
+      "slave/network_bandwidth_revocable_total"));
+  EXPECT_EQ(1u, snapshot.values.count(
+      "slave/network_bandwidth_revocable_used"));
+  EXPECT_EQ(1u, snapshot.values.count(
+      "slave/network_bandwidth_revocable_percent"));
 }
 
 


### PR DESCRIPTION
Metrics are computed for a pre-defined set of resources. I've just added
network_bandwidth to this list.

JIRA: MESOS-1190