### PR TITLE
Allow `mesos task exec/attach` for any task_id

### DIFF
--- a/src/python/cli_new/lib/cli/http.py
+++ b/src/python/cli_new/lib/cli/http.py
@@ -29,7 +29,7 @@ import cli
 from cli.exceptions import CLIException
 
 
-def read_endpoint(addr, endpoint):
+def read_endpoint(addr, endpoint, query=None):
     """
     Read the specified endpoint and return the results.
     """
@@ -41,6 +41,8 @@ def read_endpoint(addr, endpoint):
 
     try:
         url = "{addr}/{endpoint}".format(addr=addr, endpoint=endpoint)
+        if query is not None:
+          url += "?{query}".format(query=urllib.parse.urlencode(query))
         http_response = urllib.request.urlopen(url).read().decode("utf-8")
     except Exception as exception:
         raise CLIException("Unable to open url '{url}': {error}"
@@ -49,7 +51,7 @@ def read_endpoint(addr, endpoint):
     return http_response
 
 
-def get_json(addr, endpoint, condition=None, timeout=5):
+def get_json(addr, endpoint, query=None, condition=None, timeout=5):
     """
     Return the contents of the 'endpoint' at 'addr' as JSON data
     subject to the condition specified in 'condition'. If we are
@@ -62,7 +64,7 @@ def get_json(addr, endpoint, condition=None, timeout=5):
         data = None
 
         try:
-            data = read_endpoint(addr, endpoint)
+            data = read_endpoint(addr, endpoint, query)
         except Exception as exception:
             pass
 

--- a/src/python/cli_new/lib/cli/mesos.py
+++ b/src/python/cli_new/lib/cli/mesos.py
@@ -114,7 +114,7 @@ def get_container_id(task):
         " Please try again.")
 
 
-def get_tasks(master):
+def get_tasks(master, query=None):
     """
     Get the tasks in a Mesos cluster.
     """
@@ -122,17 +122,17 @@ def get_tasks(master):
     key = "tasks"
 
     try:
-        data = http.get_json(master, endpoint)
+        data = http.get_json(master, endpoint, query)
     except Exception as exception:
         raise CLIException(
-            "Could not open '/{endpoint}' on master: {error}"
-            .format(endpoint=endpoint, error=exception))
+            "Could not open '/{endpoint}' with query: {query} on master: {error}"
+            .format(endpoint=endpoint, query=query, error=exception))
 
     if not key in data:
         raise CLIException(
             "Missing '{key}' key in data retrieved"
-            " from master on '/{endpoint}'"
-            .format(key=key, endpoint=endpoint))
+            " from master on '/{endpoint}' with query: {query}}"
+            .format(key=key, endpoint=endpoint, query=query))
 
     return data[key]
 
@@ -169,11 +169,11 @@ class TaskIO():
         # "MESOS". Having a type of "MESOS" implies that it was launched by the
         # UCR -- all other types imply it was not.
         try:
-            tasks = get_tasks(master)
+            tasks = get_tasks(master, query={'task_id': task_id})
         except Exception as exception:
-            raise CLIException("Unable to get tasks from leading"
+            raise CLIException("Unable to get task {task_id} from leading"
                                " master '{master}': {error}"
-                               .format(master=master, error=exception))
+                               .format(task_id=task_id, master=master, error=exception))
 
         running_tasks = [t for t in tasks if t["state"] == "TASK_RUNNING"]
         matching_tasks = [t for t in running_tasks if t["id"] == task_id]


### PR DESCRIPTION
the `/tasks` endpoint only list the first 100 available tasks. (See docs
at http://mesos.apache.org/documentation/latest/endpoints/master/tasks/)

With this patch `mesos task exec/attach` commands will work for clusters
with more than 100 tasks.