### PR TITLE
Add temporary logs on allocator

### DIFF
--- a/src/master/allocator/mesos/hierarchical.cpp
+++ b/src/master/allocator/mesos/hierarchical.cpp
@@ -1935,6 +1935,10 @@ void HierarchicalAllocatorProcess::__allocate()
   foreach (const SlaveID& slaveId, slaveIds) {
     Slave& slave = *CHECK_NOTNONE(getSlave(slaveId));
 
+    VLOG(2) << "[Criteo] Here is the sorted list of roles that will be considered to get resources for slave " << slaveId;
+    foreach (const string& role, roleSorter->sort()) {
+        VLOG(2) << "[CRITEO] - " << role;
+    }
     foreach (const string& role, roleSorter->sort()) {
       const Quota& quota = getQuota(role);
 
@@ -1956,12 +1960,14 @@ void HierarchicalAllocatorProcess::__allocate()
       }();
 
       if (noFrameworks) {
+        VLOG(2) << "[CRITEO] " + role + " has no active framework, it will be ignored";
         continue;
       }
 
       // TODO(bmahler): Handle shared volumes, which are always available but
       // should be excluded here based on `offeredSharedResources`.
       if (slave.getAvailable().empty()) {
+        VLOG(2) << "[CRITEO] " << slaveId << " has no resource to offer anymore, skipping";
         break; // Nothing left on this agent.
       }
 
@@ -1984,6 +1990,9 @@ void HierarchicalAllocatorProcess::__allocate()
           break;
         }
 
+        Resources available = slave.getAvailable();
+        VLOG(2) << "[CRITEO] slave " << slaveId << " has following available resources: " << slave.getAvailable();
+
         // Offer a shared resource only if it has not been offered in this
         // offer cycle to a framework.
         Resources available =
@@ -1991,6 +2000,7 @@ void HierarchicalAllocatorProcess::__allocate()
           offeredSharedResources.get(slaveId).getOrElse(Resources());
 
         if (available.empty()) {
+          VLOG(2) << "[CRITEO] " + role + " cannot be allocated any resources on slave " << slaveId << " due to the allocatableTo method or because of sharedResources on that slave";
           break; // Nothing left for the role.
         }
 
@@ -2090,6 +2100,7 @@ void HierarchicalAllocatorProcess::__allocate()
         // NOTE: Since we currently only support top-level roles to
         // have quota, there are no ancestor reservations involved here.
         if (guaranteesAllocation.empty()) {
+          VLOG(2) << "[CRITEO] " + role + " has no guarantee allocation, continuing " << slaveId;
           continue;
         }
 
@@ -2138,6 +2149,7 @@ void HierarchicalAllocatorProcess::__allocate()
         // If the framework filters these resources, ignore.
         if (!allocatable(toAllocate, role, framework) ||
             isFiltered(framework, role, slave, toAllocate)) {
+          VLOG(2) << "[CRITEO] " + role + " filters these resources OR offer would be smaller than minAllocatableParameter" << slaveId;
           continue;
         }
 


### PR DESCRIPTION
We want to see what happens exactly for roles with a quota.
This patch is likely to induce conflicts when we'll rebase on later
versions

This is a cherry-pick of https://github.com/criteo-forks/mesos/pull/16.

Change-Id: Ic5850eea4679eea73f12794371c3285663ac5bdb