### PR TITLE
ExecutorHook : delete TemporaryFile after hook call

### DIFF
--- a/src/common/temporary_file.cpp
+++ b/src/common/temporary_file.cpp
@@ -16,6 +16,10 @@ TemporaryFile::TemporaryFile() {
   m_filepath = filepath.get();
 }
 
+TemporaryFile::~TemporaryFile() {
+  os::rm(m_filepath);
+}
+
 /*
  * Read whole content of the temporary file.
  * @return The content of the file.

--- a/src/common/temporary_file.hpp
+++ b/src/common/temporary_file.hpp
@@ -14,6 +14,7 @@ namespace internal {
 class TemporaryFile {
  public:
   TemporaryFile();
+  ~TemporaryFile();
   std::string readAll() const ;
   void write(const std::string& content) const;
   inline const std::string& filepath() const { return m_filepath; }

--- a/src/launcher/executor.cpp
+++ b/src/launcher/executor.cpp
@@ -550,8 +550,8 @@ protected:
       childHooks.emplace_back(Subprocess::ChildHook::SETSID());
     }
 
+    TemporaryFile inputFile;
     if(hook.isSome()) {
-      TemporaryFile inputFile;
       JSON::Object inputsJson;
       inputsJson.values["launch_info"] = JSON::protobuf(launchInfo);
       inputFile.write(stringify(inputsJson));


### PR DESCRIPTION
Last patch was not deleting the TemporaryFile after hook call.
Instead of calling `os:rm()` manually like in `mesos-command-modules`, this is done silently in the destructor instead. This will ensure file is automatically deleted when we go out of the scope of the TemporaryFile object.