### PR TITLE
Increase expected agent threshold before sending offers 

### DIFF
--- a/src/master/allocator/mesos/hierarchical.cpp
+++ b/src/master/allocator/mesos/hierarchical.cpp
@@ -523,7 +523,7 @@ void HierarchicalAllocatorProcess::recover(
 
   // TODO(alexr): Consider exposing these constants.
   const Duration ALLOCATION_HOLD_OFF_RECOVERY_TIMEOUT = Minutes(10);
-  const double AGENT_RECOVERY_FACTOR = 0.8;
+  const double AGENT_RECOVERY_FACTOR = 0.95;
 
   // Record the number of expected agents.
   expectedAgentCount =

--- a/src/master/allocator/mesos/hierarchical.cpp
+++ b/src/master/allocator/mesos/hierarchical.cpp
@@ -846,8 +846,8 @@ void HierarchicalAllocatorProcess::addSlave(
   if (paused &&
       expectedAgentCount.isSome() &&
       (static_cast<int>(slaves.size()) >= expectedAgentCount.get())) {
-    VLOG(1) << "Recovery complete: sufficient amount of agents added; "
-            << slaves.size() << " agents known to the allocator";
+    LOG(INFO) << "Recovery complete: sufficient amount of agents added; "
+              << slaves.size() << " agents known to the allocator";
 
     expectedAgentCount = None();
     resume();
@@ -1658,7 +1658,7 @@ void HierarchicalAllocatorProcess::pause()
 void HierarchicalAllocatorProcess::resume()
 {
   if (paused) {
-    VLOG(1) << "Allocation resumed";
+    LOG(INFO) << "Allocation resumed";
 
     paused = false;
   }


### PR DESCRIPTION
Upon mesos leader change, we need to make sure most agents have
re-registered to have a clear view of existing tasks to be able to
respect quotas.
The current value is hardcoded so this patch is temporary until this can
be configured in a better way.

Choice of the value:
- it needs to be >0.8 since we've already observed roles going above
their quota during leader election with 0.8
- it needs to be < 100 to favor availability of resources in case of
  dramatic event where we loose many servers at once (and having a leader
  failover).
This latter argument should also push us to also decrease ALLOCATION_HOLD_OFF_RECOVERY_TIMEOUT
but setting this value is tricky since its relationship with `--agent_reregister_timeout` option
is not entirely clear.
- there is no "good" value, it is matter of compromise

In case of dramatic event (we loose >5% of agents and have a leader
failover) we for now acknowledge that offers won't be sent before
10minutes.

Change-Id: Idf1cda5f56d5f8c169b99543e9fbab74d59c1975
Reference: https://mesos.slack.com/archives/C1NEKP60K/p1596731394006400