### PR TITLE
Hide process tree during executor termination

### DIFF
--- a/src/launcher/executor.cpp
+++ b/src/launcher/executor.cpp
@@ -979,7 +979,8 @@ private:
         // received signal before os::killtree() failed.
         os::kill(pid.get(), SIGTERM);
       } else {
-        LOG(INFO) << "Sent SIGTERM to the following process trees:\n"
+        LOG(INFO) << "Sent SIGTERM to the following process " << pid.get();
+        VLOG(2) << "Sent SIGTERM to the following process trees:\n"
                   << stringify(trees.get());
       }
 
@@ -1112,7 +1113,8 @@ private:
       // we send SIGKILL directly.
       os::kill(pid.get(), SIGKILL);
     } else {
-      LOG(INFO) << "Killed the following process trees:\n"
+      LOG(INFO) << "Sent SIGTERM to the following process " << pid.get();
+      VLOG(2) << "Killed the following process trees:\n"
                 << stringify(trees.get());
     }
   }


### PR DESCRIPTION
Some users adds secrets on their command line (intentionally or not).
It is not super safe to dispaly the process tree since those logs will
be forwarded in various logging systems.

Change-Id: Ia3469a9f6cc8a376fb8b95cfabf2029e73e43809
JIRA: VUMA-1645
Reference: https://jira.criteois.com/browse/VUMA-1645