### PR TITLE
Fix /dev/shm isolation

### DIFF
--- a/src/slave/containerizer/mesos/isolators/namespaces/ipc.cpp
+++ b/src/slave/containerizer/mesos/isolators/namespaces/ipc.cpp
@@ -111,6 +111,14 @@ Future<Option<ContainerLaunchInfo>> NamespacesIPCIsolatorProcess::prepare(
   Option<LinuxInfo::IpcMode> ipcMode;
   Option<Bytes> shmSize;
 
+  if (flags.default_ipc_mode.isSome()) {
+    if (flags.default_ipc_mode.get() == "private") {
+      ipcMode = LinuxInfo::PRIVATE;
+    } else if (flags.default_ipc_mode.get() == "share_parent") {
+      ipcMode = LinuxInfo::SHARE_PARENT;
+    }
+  }
+
   // Get the container's IPC mode and size of /dev/shm.
   if (containerConfig.has_container_info() &&
       containerConfig.container_info().has_linux_info()) {

--- a/src/slave/flags.cpp
+++ b/src/slave/flags.cpp
@@ -802,6 +802,11 @@ mesos::internal::slave::Flags::Flags()
       "pid namespace with agent if the framework requests it. This flag will\n"
       "be ignored if the `namespaces/pid` isolator is not enabled.\n",
       false);
+
+  add(&Flags::default_ipc_mode,
+      "default_ipc_mode",
+      "`private` or `share_parent`"
+      );
 #endif
 
   add(&Flags::agent_features,

--- a/src/slave/flags.hpp
+++ b/src/slave/flags.hpp
@@ -128,6 +128,7 @@ public:
   Option<Bytes> default_container_shm_size;
   bool disallow_sharing_agent_ipc_namespace;
   bool disallow_sharing_agent_pid_namespace;
+  Option<std::string> default_ipc_mode;
 #endif
   Option<Firewall> firewall_rules;
   Option<Path> credential;


### PR DESCRIPTION
By default `/dev/shm` is not isolated even when ipc namespace isolator is enabled, unless frameworks require it explicitly. The reason is that, for backward compatibility, the default behaviour on root-less top container is to share the host's `/dev/shm`. This could be easily worked around by allowing to override this default behaviour at agent level while still complying with frameworks requirements.