### PR TITLE
Fixed a bug where the slave crashes when the subnet is injected without discovery info.

### DIFF
--- a/src/slave/slave.cpp
+++ b/src/slave/slave.cpp
@@ -3665,16 +3665,18 @@ void Slave::launchExecutor(
       NetworkInfo* criteoNet = containerInfo->add_network_infos();
       criteoNet->set_name("criteo");
 
-      Ports ports = *containerConfig.mutable_executor_info()
-                       ->mutable_discovery()
-                       ->mutable_ports();
+      if(containerConfig.mutable_executor_info()->has_discovery()){
+        // We need to take the defined ports and map them in the public subnet
+        Ports ports = *containerConfig.mutable_executor_info()
+                  ->mutable_discovery()
+                  ->mutable_ports();
 
-      // We need to take the defined ports and map them in the public subnet
-      for (const auto port : *ports.mutable_ports()) {
-        auto p = criteoNet->add_port_mappings();
-        p->set_host_port(port.number());
-        p->set_container_port(port.number());
-        p->set_protocol(port.protocol());
+        for (const auto port : *ports.mutable_ports()) {
+          auto p = criteoNet->add_port_mappings();
+          p->set_host_port(port.number());
+          p->set_container_port(port.number());
+          p->set_protocol(port.protocol());
+        }
       }
     }
   }


### PR DESCRIPTION

This happens because the call to mutable_discovery() creates an object
if none exists, the slave then crashes because said object does not have
its mandatory visibility field initiated.