### PR TITLE
Do not raise an error when a framework reregisters using a new user

### DIFF
--- a/src/master/validation.cpp
+++ b/src/master/validation.cpp
@@ -614,10 +614,10 @@ Option<Error> validateUpdate(
   }
 
   if (newInfo.user() != oldInfo.user()) {
-    return Error(
-        "Updating 'FrameworkInfo.user' is unsupported"
-        "; attempted to update from '" + oldInfo.user() + "'"
-        " to '" + newInfo.user() + "'");
+    LOG(WARNING)
+      << "Updating 'FrameworkInfo.user' is unsupported"
+      << "; attempted to update from '" << oldInfo.user() << "'"
+      << " to '" << newInfo.user() << "'";
   }
 
   if (newInfo.checkpoint() != oldInfo.checkpoint()) {


### PR DESCRIPTION
Currently, it is not possible to restart an existing framework using a
new user without draining mesos agents hosting its tasks + triggering a
mesos leader election.
This is not acceptable in production.

This commit transforms the validation error into a simple warning.
This is not an issue on our infrastructure, since we always specify a
user for tasks launched by frameworks.

JIRA: MESOS-4868