### PR TITLE
Explicitely set python major version for tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
 

--- a/src/cli/mesos-cat
+++ b/src/cli/mesos-cat
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import json
 import os

--- a/src/cli/mesos-ps
+++ b/src/cli/mesos-ps
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import datetime
 import json

--- a/src/cli/mesos-scp
+++ b/src/cli/mesos-scp
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Uses 'scp' to copy local files to all slaves reported by the master.
 

--- a/src/cli/mesos-tail
+++ b/src/cli/mesos-tail
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import json
 import os


### PR DESCRIPTION
Otherwise rpm linter for centos8 does not like it

JIRA: MESOS-4966