### PR TITLE
Criteo/1.9.0 ipcfix

### DIFF
--- a/docker/resources/mesos-agent
+++ b/docker/resources/mesos-agent
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 export LD_LIBRARY_PATH=/src/mesos/src/.libs
-/src/mesos/src/.libs/mesos-agent --master=$MESOS_MASTER --port=$MESOS_PORT --hostname=$MESOS_HOSTNAME --work_dir=$MESOS_WORK_DIR --log_dir=$MESOS_LOG_DIR --containerizers=$MESOS_CONTAINERIZERS --resources=$MESOS_RESOURCES --no-systemd_enable_support --launcher_dir=$MESOS_EXEC_DIR --image_providers=docker --isolation=$MESOS_ISOLATION
+/src/mesos/src/.libs/mesos-agent --master=$MESOS_MASTER --port=$MESOS_PORT --hostname=$MESOS_HOSTNAME --work_dir=$MESOS_WORK_DIR --log_dir=$MESOS_LOG_DIR --containerizers=$MESOS_CONTAINERIZERS --resources=$MESOS_RESOURCES --no-systemd_enable_support --launcher_dir=$MESOS_EXEC_DIR --image_providers=docker --isolation=$MESOS_ISOLATION --default_ipc_mode='private'

--- a/docker/resources/mesos.yml
+++ b/docker/resources/mesos.yml
@@ -10,7 +10,7 @@ services:
       MESOS_CONTAINERIZERS: mesos
       MESOS_WORK_DIR: /var/tmp/mesos
       MESOS_LOG_DIR: /var/log/mesos
-      MESOS_ISOLATION: filesystem/linux,docker/runtime
+      MESOS_ISOLATION: filesystem/linux,docker/runtime,namespaces/ipc
       MESOS_EXEC_DIR: /src/mesos/src/
       MESOS_HOSTNAME: localhost
     volumes:

--- a/src/slave/containerizer/mesos/isolators/namespaces/ipc.cpp
+++ b/src/slave/containerizer/mesos/isolators/namespaces/ipc.cpp
@@ -123,6 +123,13 @@ Future<Option<ContainerLaunchInfo>> NamespacesIPCIsolatorProcess::prepare(
     }
   }
 
+  string user;
+  if (containerConfig.has_user()) {
+    user = containerConfig.user();
+  } else {
+    user = "0";
+  }
+
   // Get the container's IPC mode and size of /dev/shm.
   if (containerConfig.has_container_info() &&
       containerConfig.container_info().has_linux_info()) {
@@ -172,7 +179,7 @@ Future<Option<ContainerLaunchInfo>> NamespacesIPCIsolatorProcess::prepare(
             "tmpfs",
             path::join(containerConfig.rootfs(), "/dev/shm"),
             "tmpfs",
-            "mode=1777",
+            strings::format("mode=0700,uid=%s", user).get(),
             MS_NOSUID | MS_NODEV | MS_STRICTATIME);
       }
     } else {
@@ -199,8 +206,8 @@ Future<Option<ContainerLaunchInfo>> NamespacesIPCIsolatorProcess::prepare(
               "tmpfs",
               MS_NOSUID | MS_NODEV | MS_STRICTATIME,
               shmSize.isSome() ?
-                strings::format("mode=1777,size=%d", shmSize->bytes()).get() :
-                "mode=1777");
+                strings::format("mode=0700,size=%d,uid=%s", shmSize->bytes(), user).get() :
+                strings::format("mode=0700,uid=%s", user).get());
 
           if (mnt.isError()) {
             return Failure("Failed to mount '" + shmPath + "': " + mnt.error());
@@ -267,7 +274,7 @@ Future<Option<ContainerLaunchInfo>> NamespacesIPCIsolatorProcess::prepare(
             "tmpfs",
             path::join(containerConfig.rootfs(), "/dev/shm"),
             "tmpfs",
-            "mode=1777",
+            strings::format("mode=0700,uid=%s", user).get(),
             MS_NOSUID | MS_NODEV | MS_STRICTATIME);
       }
     } else {
@@ -295,8 +302,8 @@ Future<Option<ContainerLaunchInfo>> NamespacesIPCIsolatorProcess::prepare(
               "tmpfs",
               MS_NOSUID | MS_NODEV | MS_STRICTATIME,
               shmSize.isSome() ?
-                strings::format("mode=1777,size=%d", shmSize->bytes()).get() :
-                "mode=1777");
+                strings::format("mode=0700,size=%d,uid=%s", shmSize->bytes(), user).get() :
+                strings::format("mode=0700,uid=%s", user).get());
 
           if (mnt.isError()) {
             return Failure("Failed to mount '" + shmPath + "': " + mnt.error());

--- a/src/slave/containerizer/mesos/isolators/namespaces/ipc.cpp
+++ b/src/slave/containerizer/mesos/isolators/namespaces/ipc.cpp
@@ -14,6 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <pwd.h>
+
 #include <string>
 
 #include <process/future.hpp>
@@ -47,6 +49,23 @@ using mesos::slave::Isolator;
 namespace mesos {
 namespace internal {
 namespace slave {
+
+// Small C helper which looks up the login of a user in passwd
+// and returns its UID. Handy to provide right perms on mountpoints
+// We should use the reentrant version as it's unsure this can be called
+// several times (many containers can start at once).
+string uidfromlogin(string login)
+{
+    struct passwd pwd;
+    struct passwd* result = NULL;
+    char buf[2048];
+
+    memset(&buf, 0, sizeof buf);
+    if(!getpwnam_r(login.c_str(), &pwd, buf, sizeof buf, &result))
+        return std::to_string(pwd.pw_uid);
+
+    return "0";
+}
 
 Try<Isolator*> NamespacesIPCIsolatorProcess::create(const Flags& flags)
 {
@@ -123,12 +142,11 @@ Future<Option<ContainerLaunchInfo>> NamespacesIPCIsolatorProcess::prepare(
     }
   }
 
-  string user;
-  if (containerConfig.has_user()) {
-    user = containerConfig.user();
-  } else {
-    user = "0";
-  }
+  string user = "0";
+  if (containerConfig.has_user())
+    user = uidfromlogin(containerConfig.user());
+
+  string mountopts = strings::format("mode=0700,uid=%s", user).get();
 
   // Get the container's IPC mode and size of /dev/shm.
   if (containerConfig.has_container_info() &&
@@ -179,7 +197,7 @@ Future<Option<ContainerLaunchInfo>> NamespacesIPCIsolatorProcess::prepare(
             "tmpfs",
             path::join(containerConfig.rootfs(), "/dev/shm"),
             "tmpfs",
-            strings::format("mode=0700,uid=%s", user).get(),
+            mountopts,
             MS_NOSUID | MS_NODEV | MS_STRICTATIME);
       }
     } else {
@@ -206,8 +224,8 @@ Future<Option<ContainerLaunchInfo>> NamespacesIPCIsolatorProcess::prepare(
               "tmpfs",
               MS_NOSUID | MS_NODEV | MS_STRICTATIME,
               shmSize.isSome() ?
-                strings::format("mode=0700,size=%d,uid=%s", shmSize->bytes(), user).get() :
-                strings::format("mode=0700,uid=%s", user).get());
+                strings::format("%s,size=%d", mountopts, shmSize->bytes()).get() :
+                mountopts);
 
           if (mnt.isError()) {
             return Failure("Failed to mount '" + shmPath + "': " + mnt.error());
@@ -274,7 +292,7 @@ Future<Option<ContainerLaunchInfo>> NamespacesIPCIsolatorProcess::prepare(
             "tmpfs",
             path::join(containerConfig.rootfs(), "/dev/shm"),
             "tmpfs",
-            strings::format("mode=0700,uid=%s", user).get(),
+            mountopts,
             MS_NOSUID | MS_NODEV | MS_STRICTATIME);
       }
     } else {
@@ -302,8 +320,8 @@ Future<Option<ContainerLaunchInfo>> NamespacesIPCIsolatorProcess::prepare(
               "tmpfs",
               MS_NOSUID | MS_NODEV | MS_STRICTATIME,
               shmSize.isSome() ?
-                strings::format("mode=0700,size=%d,uid=%s", shmSize->bytes(), user).get() :
-                strings::format("mode=0700,uid=%s", user).get());
+                strings::format("%s,size=%d", mountopts, shmSize->bytes()).get() :
+                mountopts);
 
           if (mnt.isError()) {
             return Failure("Failed to mount '" + shmPath + "': " + mnt.error());


### PR DESCRIPTION
Fixes the IPC isolator:
```
[root@localhost mesos]# getent passwd nobody
nobody:x:99:99:Nobody:/:/sbin/nologin
[root@localhost mesos]# mount|grep shm
shm on /dev/shm type tmpfs (rw,nosuid,nodev,noexec,relatime,size=65536k,inode64)
tmpfs on /run/mesos/containers/c241f9a4-9af2-4c82-9e1e-c5e835183f00/shm type tmpfs (rw,nosuid,nodev,mode=700,uid=99,inode64)
[root@localhost mesos]# ls -l /run/mesos/containers/c241f9a4-9af2-4c82-9e1e-c5e835183f00/
total 12
-rw------- 1 root   root 2574 Sep 27 15:38 config
-rw------- 1 root   root 1909 Sep 27 15:38 launch_info
-rw------- 1 root   root    2 Sep 27 15:38 pid
drwx------ 2 nobody root   40 Sep 27 15:38 shm
-rw------- 1 root   root    0 Sep 27 15:38 status
[root@localhost mesos]# 
```

IPC isolator now sets the right permissions on the mount point to allow a container to safely store private data