### PR TITLE
Ignored the directoy `/dev/nvidia-caps` when globing Nvidia GPU devices.

### DIFF
--- a/src/slave/containerizer/mesos/isolators/gpu/isolator.cpp
+++ b/src/slave/containerizer/mesos/isolators/gpu/isolator.cpp
@@ -443,6 +443,15 @@ Future<Option<ContainerLaunchInfo>> NvidiaGpuIsolatorProcess::_prepare(
   }
 
   foreach (const string& device, nvidia.get()) {
+    // The directory `/dev/nvidia-caps` was introduced in CUDA 11.0, just
+    // ignore it since we only care about the Nvidia GPU device files.
+    //
+    // TODO(qianzhang): Figure out how to handle the directory
+    // `/dev/nvidia-caps` more properly.
+    if (device == "/dev/nvidia-caps") {
+      continue;
+    }
+
     const string devicePath = path::join(
         devicesDir, strings::remove(device, "/dev/", strings::PREFIX), device);
 


### PR DESCRIPTION
The directory `/dev/nvidia-caps` was introduced in CUDA 11.0, just
ignore it since we only care about the Nvidia GPU device files.

Review: https://reviews.apache.org/r/72945
(cherry picked from commit 301902be4f1332799cf3b3242cd29b4907c21c09)