### PR TITLE
Fixing GPU isolation, take 2

### DIFF
--- a/src/slave/containerizer/mesos/isolators/gpu/volume.cpp
+++ b/src/slave/containerizer/mesos/isolators/gpu/volume.cpp
@@ -221,6 +221,15 @@ Environment NvidiaVolume::ENV(const ImageManifest& manifest) const
     }
   }
 
+  const char* path_env = std::getenv("PATH");
+
+  if (path_env && !paths.size())  {
+      /* FIXME(t.lange): we should merge existing vars */
+      const vector<string> existing_path = strings::tokenize(path_env, ":");
+      paths.insert(paths.end(), existing_path.begin(), existing_path.end());
+      LOG(INFO) << "Defaulting to existing $PATH: " << path_env;
+  }
+
   // Inject the `PATH` and `LD_LIBRARY_PATH` environment variables.
   const string binaryPath = path::join(containerPath, "bin");
   if (std::find(paths.begin(), paths.end(), binaryPath) == paths.end()) {


### PR DESCRIPTION
Previous patch was incomplete and buggy for those two reasons:
* we used to check launchInfo for presence of ENV despite it is the
  strucutre returned by the isolator itself. We now check in the task
  specification itself
* the isolator adds a PATH environment variable based on the env of the
  Docker image manifest, which can be empty. As this PATH
  overrides the one in the existing ENV (like any other env variable in
  Mesos), this can laed to executing task with a PATH set to nvidia bin
  dir only. This patch makes the isolator default to the env to ensure
  we don't set an empty path. In the case a task sets the PATH, it will
  be used and the user will have to append nvidia path anyway.

JIRA: MESOS-5563